### PR TITLE
Update the host to JuliaData in badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![DataStreams](http://pkg.julialang.org/badges/DataStreams_0.4.svg)](http://pkg.julialang.org/?pkg=DataStreams&ver=0.4)
 [![DataStreams](http://pkg.julialang.org/badges/DataStreams_0.5.svg)](http://pkg.julialang.org/?pkg=DataStreams)
 
-Linux and OS X: [![Build Status](https://travis-ci.org/JuliaDB/DataStreams.jl.svg?branch=master)](https://travis-ci.org/JuliaDB/DataStreams.jl)
+Linux and OS X: [![Build Status](https://travis-ci.org/JuliaData/DataStreams.jl.svg?branch=master)](https://travis-ci.org/JuliaData/DataStreams.jl)
 
-Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaDB/DataStreams.jl?branch=master&svg=true)](https://ci.appveyor.com/project/JuliaDB/datastreams-jl/branch/master)
+Windows: [![Build Status](https://ci.appveyor.com/api/projects/status/github/JuliaData/DataStreams.jl?branch=master&svg=true)](https://ci.appveyor.com/project/JuliaData/datastreams-jl/branch/master)
 
-[![codecov.io](http://codecov.io/github/JuliaDB/DataStreams.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaDB/DataStreams.jl?branch=master)
+[![codecov.io](http://codecov.io/github/JuliaData/DataStreams.jl/coverage.svg?branch=master)](http://codecov.io/github/JuliaData/DataStreams.jl?branch=master)
 
 The `DataStreams.jl` packages defines a data processing framework based on Sources, Sinks, and the `Data.stream!` function.
 


### PR DESCRIPTION
The repo got a new home (JuliaData) but the badge URLs still point to the old one (JuliaDB).