### PR TITLE
Explicitly provide type for function dictionary

### DIFF
--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -77,7 +77,7 @@ function transform(sch::Data.Schema, transforms::Dict{Int,Function})
     end
     return Schema(Data.header(sch), newtypes, size(sch, 1), sch.metadata), transforms2
 end
-transform(sch::Data.Schema, transforms::Dict{String,Function}) = transform(sch, Dict(sch[x]=>f for (x,f) in transforms))
+transform(sch::Data.Schema, transforms::Dict{String,Function}) = transform(sch, Dict{Int,Function}(sch[x]=>f for (x,f) in transforms))
 
 # Data.Source Interface
 abstract Source

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,3 +42,13 @@ src_tb = DataFrame()
 snk = TableSink(sch)
 
 snk_tb = Data.stream!(src_tb, snk)
+
+schema = Data.Schema(["A", "B"], [Int64, String])
+transforms = Dict{String, Function}("A" => (x) -> -x, "B" => lowercase)
+sink_schema, transforms2 = Data.transform(schema, transforms)
+@test transforms2 == [transforms["A"], transforms["B"]]
+
+schema = Data.Schema(["A", "B"], [Int64, String])
+transforms = Dict{String, Function}("B" => lowercase)
+sink_schema, transforms2 = Data.transform(schema, transforms)
+@test transforms2 == [identity, transforms["B"]]


### PR DESCRIPTION
In the case of a single transform in the transforms argument `Dict`,
`transforms` is incorrectly inferring the `Dict` value-type as the
specific transform function singleton type (`#function_name`) rather
than the generic `Function`, causing a `MethodError`, e.g.

```
ERROR: MethodError: no method matching transform(::DataStreams.Data.Schema{true}, ::Dict{Int64,#function_name})
```