### PR TITLE
Next iteration of DataStreams API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
   - osx
 
 julia:
-  - 0.5
+  - 0.6
   - nightly
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 | **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.4-img]][pkg-0.4-url] [![][pkg-0.5-img]][pkg-0.5-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.6-img]][pkg-0.6-url] [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Installation
@@ -23,7 +23,7 @@ julia> Pkg.add("DataStreams")
 
 ## Project Status
 
-The package is tested against Julia `0.4` and *current* `0.5` on Linux, OS X, and Windows.
+The package is tested against Julia `0.6` and *current* `0.7`/`1.0` on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 
@@ -49,7 +49,7 @@ Contributions are very welcome, as are feature requests and suggestions. Please 
 
 [issues-url]: https://github.com/JuliaData/DataStreams.jl/issues
 
-[pkg-0.4-img]: http://pkg.julialang.org/badges/DataStreams_0.4.svg
-[pkg-0.4-url]: http://pkg.julialang.org/?pkg=DataStreams
-[pkg-0.5-img]: http://pkg.julialang.org/badges/DataStreams_0.5.svg
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=DataStreams
+[pkg-0.6-img]: http://pkg.julialang.org/badges/DataStreams_0.6.svg
+[pkg-0.6-url]: http://pkg.julialang.org/?pkg=DataStreams
+[pkg-0.7-img]: http://pkg.julialang.org/badges/DataStreams_0.7.svg
+[pkg-0.7-url]: http://pkg.julialang.org/?pkg=DataStreams

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-WeakRefStrings
-Nulls
+WeakRefStrings 0.3.0
+Nulls 0.0.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,3 @@
-julia 0.5
-DataFrames
-NullableArrays 0.0.9
-CategoricalArrays 0.0.5
-WeakRefStrings 0.1.3
-Compat 0.17
+julia 0.6
+WeakRefStrings
+Nulls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -18,10 +18,10 @@ A `Data.Schema` describes a tabular dataset (i.e. a set of optionally named, typ
  * `Data.types(schema)` to return the column types in a `Data.Schema`; `Nullable{T}` indicates columns that may contain missing data (null values)
  * `Data.size(schema)` to return the (# of rows, # of columns) in a `Data.Schema`; note that # of rows may be `null`, meaning unknown
 """
-type Schema{R, T}
+type Schema{R <: ?Int, T}
     header::Vector{String}       # column names
     # types::T                     # Julia types of columns
-    rows::(?Int)                 # number of rows in the dataset
+    rows::R                      # number of rows in the dataset
     cols::Int                    # number of columns in a dataset
     metadata::Dict               # for any other metadata we'd like to keep around (not used for '==' operation)
     index::Dict{String, Int}     # maps column names as Strings to their index # in `header` and `types`
@@ -32,7 +32,7 @@ function Schema{T <: Tuple}(header::Vector, types::T, rows::?(Integer)=0, metada
     cols = length(header)
     cols != length(types) && throw(ArgumentError("length(header): $(length(header)) must == length(types): $(length(types))"))
     header = String[string(x) for x in header]
-    return Schema{!isnull(rows), Tuple{types...}}(header, rows, cols, metadata, Dict(n=>i for (i, n) in enumerate(header)))
+    return Schema{typeof(rows), Tuple{types...}}(header, rows, cols, metadata, Dict(n=>i for (i, n) in enumerate(header)))
 end
 
 Schema(header::Vector, types::Vector, rows::?(Integer)=0, metadata::Dict=Dict()) = Schema(header, Tuple(types), rows, metadata)
@@ -60,23 +60,18 @@ function Base.show{R, T}(io::IO, schema::Schema{R, T})
     end
 end
 
-function transform(sch::Data.Schema, transforms::Dict{Int, Function})
+function transform{R, T}(sch::Data.Schema{R, T}, transforms::Dict{Int, Function})
     types = Data.types(sch)
-    newtypes = []
-    transforms2 = Function[]
-    for (i, T) in enumerate(types)
-        f = get(transforms, i, identity)
-        push!(newtypes, Core.Inference.return_type(f, (T,)))
-        push!(transforms2, f)
-    end
-    return Schema(Data.header(sch), Tuple(newtypes), size(sch, 1), sch.metadata), transforms2
+    transforms2 = ((get(transforms, x, identity) for x = 1:length(types))...)
+    newtypes = ((Core.Inference.return_type(transforms2[x], (types[x],)) for x = 1:length(types))...)
+    return Schema(Data.header(sch), newtypes, size(sch, 1), sch.metadata), transforms2
 end
 transform(sch::Data.Schema, transforms::Dict{String,Function}) = transform(sch, Dict{Int, Function}(sch[x]=>f for (x, f) in transforms))
 
 # Data.StreamTypes
 @compat abstract type StreamType end
-struct Row <: StreamType end
-struct Batch <: StreamType end
+struct Field <: StreamType end
+struct Column <: StreamType end
 
 # Data.Source Interface
 @compat abstract type Source end
@@ -115,7 +110,7 @@ function close! end
 
 # Generic fallbacks
 cleanup!(sink) = nothing
-close!(sink) = nothing
+close!(sink) = sink
 
 # Data.stream!
 function stream! end
@@ -133,7 +128,7 @@ function Data.stream!{So, Si}(source::So, ::Type{Si}, args...;
     for sinkstreamtype in sinkstreamtypes
         if Data.streamtype(So, sinkstreamtype)
             source_schema = Data.schema(source)
-            sink_schema, transforms2 = transform(source_schema, transforms)
+            sink_schema, transforms2 = Data.transform(source_schema, transforms)
             sink = Si(sink_schema, sinkstreamtype, append, args...; kwargs...)
             return Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
         end
@@ -158,42 +153,54 @@ function Data.stream!{So, Si}(source::So, sink::Si;
     throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
 end
 
-# internal streaming machinery
-function generate_inner_loop(knownrows)
-    if !knownrows
-        return quote
-            while true
-                @inbounds for col = 1:cols
-                    # println("streaming with unknown rows, row = $row, col = $col...")
-                    Data.streamto!(sink, Data.Row, source, sourcetypes[col], sinktypes[col], row, col, sink_schema, transforms[col])
-                end
-                row += 1
-                Data.isdone(source, row, cols) && break
-            end
-            Data.setrows!(source, row - 1)
-        end
-    else
-        return quote
-            @inbounds for row = 1:rows, col = 1:cols
-                # println("streaming with known rows, sinkrows = $sinkrows, row = $row, col = $col...")
-                Data.streamto!(sink, Data.Row, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
-            end
-        end
-    end
-end
+# variables
+  # row vs. batch
+  # known source rows
+  # column selecting
+  # RandomAccess
+  # row filtering
+  # transform functions
+#
 
-@generated function Data.stream!{So, Si, R1, R2, T1, T2}(source::So, ::Type{Data.Row}, sink::Si,
-    source_schema::Schema{R1, T1}, sink_schema::Schema{R2, T2},
-    transforms, filter, columns)
+# column filtering
+ # Data.transforms needs to produce sink schema w/ correct #/types of columns
+ # if RandomAccess
+   # only generate @nexprs for selected column #s, need to pass in column offset or something to map between source co
+ # else
+  # generate normal # of @nexprs, but only need to include Data.streamto! for included columns
+
+# row filtering
+ # needs to update source schema to be unknown # of rows? or maybe that gets set earlier?
+ # where func: (tuple) -> Bool or (tuple, row) -> Bool
+ # probably do @nexprs for streamfroms first, then apply where func
+ # if where = true, execute @nexprs streamto!, else continue
+
+# WeakRefStringArray
+ # source provides Schema that includes WeakRefString types
+ # SupportsWeakRefString trait
+ # Data.transform can convert to regular String type if sink doesn't support
+ # pass tuple of reference columns to Sink constructor
+ # sink constructor needs to allocate WeakRefStringArray w/ source reference columns
+ # setindex(A, WeakRefString(ptr, idx, len), i)
+ # CSV.parsefield(src, WeakRefString) => WeakRefString(ptr, idx, len)
+ # keep Data.reference?
+
+@generated function Data.stream!{So, Si, T1}(source::So, ::Type{Data.Field}, sink::Si,
+    source_schema::Schema{Int, T1}, sink_schema, transforms, filter, columns)
+    sourcetypes = Tuple(T1.parameters)
+    N = length(sourcetypes)
     return quote
         Data.isdone(source, 1, 1) && return sink
-        rows, cols = size(source_schema)
-        sinkrows = max(0, size(sink_schema, 1) - rows)
-        sourcetypes = $(Tuple(T1.parameters))
-        sinktypes = $(Tuple(T2.parameters))
-        row = 1
+        rows, cols = size(source_schema)::Tuple{Int, Int}
+        sinkrows = max(0, size(sink_schema, 1)::Int - rows)
+        sourcetypes = $sourcetypes
         try
-            $(generate_inner_loop(R1))
+            @inbounds for row = 1:rows
+                Base.@nexprs $N col->begin
+                    val_col = transforms[col](Data.streamfrom(source, Data.Field, sourcetypes[col], sinkrows + row, col))
+                    Data.streamto!(sink, Data.Field, val_col, sinkrows + row, col, Val{true})
+                end
+            end
         catch e
             Data.cleanup!(sink)
             rethrow(e)
@@ -202,42 +209,104 @@ end
     end
 end
 
-function streamto!{T, TT}(sink, ::Type{Data.Row}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
-    val = f(Data.streamfrom(source, Data.Row, T, row, col))
-    # println("streamed val = $val")
-    return Data.streamto!(sink, Data.Row, val, row, col, sch)
-end
-streamto!{T <: StreamType}(sink, ::Type{T}, val, row, col, sch) = streamto!(sink, T, val, row, col)
-
-function streamto!{T, TT}(sink, ::Type{Data.Batch}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
-    column = f(Data.streamfrom(source, Data.Batch, T, col)::T)::TT
-    return streamto!(sink, Data.Batch, column, row, col, sch)
-end
-
-function Data.stream!{T1, T2}(source::T1, ::Type{Data.Batch}, sink::T2, source_schema, sink_schema, transforms)
-    Data.isdone(source, 1, 1) && return sink
-    rows, cols = size(source_schema)
-    sinkrows = max(0, size(sink_schema, 1) - rows)
-    sourcetypes = Data.types(source_schema)
-    sinktypes = Data.types(sink_schema)
-    row = cur_row = 0
-    try
-        @inbounds for col = 1:cols
-            row = Data.streamto!(sink, Data.Batch, source, sourcetypes[col], sinktypes[col], sinkrows + cur_row, col, sink_schema, transforms[col])
-        end
-        while !Data.isdone(source, row+1, cols)
-            @inbounds for col = 1:cols
-                cur_row = Data.streamto!(sink, Data.Batch, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
+@generated function Data.stream!{So, Si, T1}(source::So, ::Type{Data.Field}, sink::Si,
+    source_schema::Schema{Null, T1}, sink_schema, transforms, filter, columns)
+    sourcetypes = Tuple(T1.parameters)
+    N = length(sourcetypes)
+    return quote
+        Data.isdone(source, 1, 1) && return sink
+        rows, cols = size(source_schema)
+        sinkrows = max(0, size(sink_schema, 1))
+        sourcetypes = $sourcetypes
+        try
+            $(
+            # unknown # of rows
+            quote
+                row = 1
+                while true
+                    Base.@nexprs $N col->begin
+                        val_col = transforms[col](Data.streamfrom(source, Data.Field, sourcetypes[col], sinkrows + row, col))
+                        Data.streamto!(sink, Data.Field, val_col, sinkrows + row, Val{col}, Val{false})
+                    end
+                    Data.isdone(source, row, cols) && break
+                    row += 1
+                end
             end
-            row += cur_row
+            )
+            Data.setrows!(source, row)
+        catch e
+            Data.cleanup!(sink)
+            rethrow(e)
         end
-        Data.setrows!(source, row)
-    catch e
-        Data.cleanup!(sink)
-        rethrow(e)
+        return sink
     end
-    return sink
 end
+
+@generated function Data.stream!{So, Si, R1, T1}(source::So, ::Type{Data.Column}, sink::Si,
+    source_schema::Schema{R1, T1}, sink_schema, transforms, filter, columns)
+    sourcetypes = Tuple(T1.parameters)
+    N = length(sourcetypes)
+    return quote
+        Data.isdone(source, 1, 1) && return sink
+        rows, cols = size(source_schema)
+        sinkrows = max(0, size(sink_schema, 1) - rows)
+        sourcetypes = $sourcetypes
+        try
+            $(quote
+                row = cur_row = 0
+                while !Data.isdone(source, row+1, cols)
+                    Base.@nexprs $N col->begin
+                        column_col = transforms[col](Data.streamfrom(source, Data.Column, sourcetypes[col], col))
+                        cur_row = Data.streamto!(sink, Data.Column, column_col, sinkrows + row, col, $(Val{R1}))
+                    end
+                    row += cur_row
+                end
+            end)
+            Data.setrows!(source, row)
+        catch e
+            Data.cleanup!(sink)
+            rethrow(e)
+        end
+        return sink
+    end
+end
+
+# function streamto!{T, TT}(sink, ::Type{Data.Field}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
+#     val = f(Data.streamfrom(source, Data.Field, T, row, col))
+#     # println("streamed val = $val")
+#     return Data.streamto!(sink, Data.Field, val, row, col, sch)
+# end
+# streamto!{T <: StreamType}(sink, ::Type{T}, val, row, col, knownrows) = streamto!(sink, T, val, row, col)
+
+# function streamto!{T, TT}(sink, ::Type{Data.Column}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
+#     column = f(Data.streamfrom(source, Data.Column, T, col)::T)::TT
+#     return streamto!(sink, Data.Column, column, row, col, sch)
+# end
+#
+# function Data.stream!{T1, T2}(source::T1, ::Type{Data.Column}, sink::T2, source_schema, sink_schema, transforms)
+#     Data.isdone(source, 1, 1) && return sink
+#     rows, cols = size(source_schema)
+#     sinkrows = max(0, size(sink_schema, 1) - rows)
+#     sourcetypes = Data.types(source_schema)
+#     sinktypes = Data.types(sink_schema)
+#     row = cur_row = 0
+#     try
+#         @inbounds for col = 1:cols
+#             row = Data.streamto!(sink, Data.Column, source, sourcetypes[col], sinktypes[col], sinkrows + cur_row, col, sink_schema, transforms[col])
+#         end
+#         while !Data.isdone(source, row+1, cols)
+#             @inbounds for col = 1:cols
+#                 cur_row = Data.streamto!(sink, Data.Column, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
+#             end
+#             row += cur_row
+#         end
+#         Data.setrows!(source, row)
+#     catch e
+#         Data.cleanup!(sink)
+#         rethrow(e)
+#     end
+#     return sink
+# end
 
 end # module Data
 

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -303,7 +303,7 @@ function generate_loop(::Type{Val{knownrows}}, ::Type{S}, inner_loop) where {kno
             Data.setrows!(source, row)
         end
     end
-    println(macroexpand(loop))
+    # println(macroexpand(loop))
     return loop
 end
 

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -1,15 +1,11 @@
 __precompile__(true)
 module DataStreams
 
-export Data, DataFrame
+export Data
 
 module Data
 
-using Compat
-
-@compat abstract type StreamType end
-immutable Field <: StreamType end
-immutable Column <: StreamType end
+using Compat, Nulls
 
 # Data.Schema
 """
@@ -18,68 +14,69 @@ A `Data.Schema` describes a tabular dataset (i.e. a set of optionally named, typ
 `Data.Schema` allow `Data.Source` and `Data.Sink` to talk to each other and prepare to provide/receive data through streaming.
 `Data.Schema` fields include:
 
- * A boolean type parameter that indicates whether the # of rows is known in the `Data.Source`; this is useful as a type parameter to allow `Data.Sink` and `Data.streamto!` methods to dispatch. Note that the sentinel value `-1` is used as the # of rows when the # of rows is unknown.
  * `Data.header(schema)` to return the header/column names in a `Data.Schema`
  * `Data.types(schema)` to return the column types in a `Data.Schema`; `Nullable{T}` indicates columns that may contain missing data (null values)
- * `Data.size(schema)` to return the (# of rows, # of columns) in a `Data.Schema`
-
-`Data.Source` and `Data.Sink` interfaces both require that `Data.schema(source_or_sink)` be defined to ensure
-that other `Data.Source`/`Data.Sink` can work appropriately.
+ * `Data.size(schema)` to return the (# of rows, # of columns) in a `Data.Schema`; note that # of rows may be `null`, meaning unknown
 """
-type Schema{RowsAreKnown}
+type Schema{R, T}
     header::Vector{String}       # column names
-    types::Vector{DataType}      # Julia types of columns
-    rows::Int                    # number of rows in the dataset
+    # types::T                     # Julia types of columns
+    rows::(?Int)                 # number of rows in the dataset
     cols::Int                    # number of columns in a dataset
-    metadata::Dict{Any, Any}     # for any other metadata we'd like to keep around (not used for '==' operation)
-    index::Dict{String,Int}      # maps column names as Strings to their index # in `header` and `types`
+    metadata::Dict               # for any other metadata we'd like to keep around (not used for '==' operation)
+    index::Dict{String, Int}     # maps column names as Strings to their index # in `header` and `types`
 end
 
-function Schema(header::Vector, types::Vector{DataType}, rows::Integer=0, metadata::Dict=Dict())
-    rows < -1 && throw(ArgumentError("Invalid # of rows for Schema; use -1 to indicate an unknown # of rows"))
+function Schema{T <: Tuple}(header::Vector, types::T, rows::?(Integer)=0, metadata::Dict=Dict())
+    !isnull(rows) && rows < 0 && throw(ArgumentError("Invalid # of rows for Schema; use `null` to indicate an unknown # of rows"))
     cols = length(header)
     cols != length(types) && throw(ArgumentError("length(header): $(length(header)) must == length(types): $(length(types))"))
     header = String[string(x) for x in header]
-    return Schema{rows > -1}(header, types, rows, cols, metadata, Dict(n=>i for (i, n) in enumerate(header)))
+    return Schema{!isnull(rows), Tuple{types...}}(header, rows, cols, metadata, Dict(n=>i for (i, n) in enumerate(header)))
 end
 
-Schema(types::Vector{DataType}, rows::Integer=0, meta::Dict=Dict()) = Schema(String["Column$i" for i = 1:length(types)], types, rows, meta)
-Schema() = Schema(String[], DataType[], 0, Dict())
+Schema(header::Vector, types::Vector, rows::?(Integer)=0, metadata::Dict=Dict()) = Schema(header, Tuple(types), rows, metadata)
+Schema(types, rows::?(Integer)=0, meta::Dict=Dict()) = Schema(String["Column$i" for i = 1:length(types)], Tuple(types), rows, meta)
+Schema() = Schema(String[], DataType[], null, Dict())
 
 header(sch::Schema) = sch.header
-types(sch::Schema) = sch.types
+types{R, T}(sch::Schema{R, T}) = Tuple(T.parameters)
 Base.size(sch::Schema) = (sch.rows, sch.cols)
 Base.size(sch::Schema, i::Int) = ifelse(i == 1, sch.rows, ifelse(i == 2, sch.cols, 0))
 
 header(source_or_sink) = header(schema(source_or_sink))
-types{T <: StreamType}(source_or_sink, ::Type{T}=Field) = types(schema(source_or_sink, T))
 setrows!(source, rows) = isdefined(source, :schema) ? (source.schema.rows = rows; nothing) : nothing
 
 Base.getindex(sch::Schema, col::String) = sch.index[col]
 
-function Base.show{b}(io::IO, schema::Schema{b})
-    println(io, "Data.Schema{$(b)}:")
+function Base.show{R, T}(io::IO, schema::Schema{R, T})
+    println(io, "Data.Schema:")
     println(io, "rows: $(schema.rows)\tcols: $(schema.cols)")
     if schema.cols <= 0
         println(io)
     else
         println(io, "Columns:")
-        Base.print_matrix(io, hcat(schema.header, schema.types))
+        Base.print_matrix(io, hcat(schema.header, collect(T.parameters)))
     end
 end
 
-function transform(sch::Data.Schema, transforms::Dict{Int,Function})
+function transform(sch::Data.Schema, transforms::Dict{Int, Function})
     types = Data.types(sch)
-    newtypes = similar(types)
-    transforms2 = Array{Function}(length(types))
+    newtypes = []
+    transforms2 = Function[]
     for (i, T) in enumerate(types)
         f = get(transforms, i, identity)
-        newtypes[i] = Core.Inference.return_type(f, (T,))
-        transforms2[i] = f
+        push!(newtypes, Core.Inference.return_type(f, (T,)))
+        push!(transforms2, f)
     end
-    return Schema(Data.header(sch), newtypes, size(sch, 1), sch.metadata), transforms2
+    return Schema(Data.header(sch), Tuple(newtypes), size(sch, 1), sch.metadata), transforms2
 end
-transform(sch::Data.Schema, transforms::Dict{String,Function}) = transform(sch, Dict{Int,Function}(sch[x]=>f for (x,f) in transforms))
+transform(sch::Data.Schema, transforms::Dict{String,Function}) = transform(sch, Dict{Int, Function}(sch[x]=>f for (x, f) in transforms))
+
+# Data.StreamTypes
+@compat abstract type StreamType end
+struct Row <: StreamType end
+struct Batch <: StreamType end
 
 # Data.Source Interface
 @compat abstract type Source end
@@ -95,30 +92,15 @@ Indicates whether the source `T` supports streaming of type `S`. To be overloade
 function streamtype end
 function streamfrom end
 
-# Optional method
-# size(source)
-# size(source, i)
-function reference end
-
 # Generic fallbacks
-Base.size(s::Source) = size(schema(s, Data.Field))
-Base.size(s::Source, i) = size(schema(s, Data.Field), i)
-schema(source) = schema(source, Data.Field)
-function schema(source, ::Type{Data.Field})
-    sch = Data.schema(source, Data.Column)
-    types = DataType[eltype(TT) for TT in Data.types(sch)]
-    return Schema(Data.header(sch), types, size(sch, 1), sch.metadata)
-end
 Data.streamtype{T <: StreamType}(source, ::Type{T}) = false
-reference(x) = UInt8[]
-#TODO: fallback for streamfrom for Nullables
 
 # Data.Sink Interface
 @compat abstract type Sink end
 
 # Required methods
-# Sink(sch::Data.Schema, S, append, ref, args...; kwargs...)
-# Sink(sink, sch::Data.Schema, S, append, ref)
+# Sink(sch::Data.Schema, S, append, args...; kwargs...)
+# Sink(sink, sch::Data.Schema, S, append)
 """
 `Data.streamtypes{T<:Data.Sink}(::Type{T})` => Vector{StreamType}
 
@@ -128,8 +110,6 @@ function streamtypes end
 function streamto! end
 
 # Optional methods
-# size(source)
-# size(source, i)
 function cleanup! end
 function close! end
 
@@ -140,86 +120,101 @@ close!(sink) = nothing
 # Data.stream!
 function stream! end
 
-# generic definitions
-function Data.stream!{So, Si}(source::So, ::Type{Si}, append::Bool, transforms::Dict, args...; kwargs...)
+# generic public definitions
+const TRUE = x->true
+# the 2 methods below are safe and expected to be called from higher-level package convenience functions (e.g. CSV.read)
+function Data.stream!{So, Si}(source::So, ::Type{Si}, args...;
+                                append::Bool=false,
+                                transforms::Dict=Dict{Int, Function}(),
+                                filter::Function=TRUE,
+                                columns::Vector=[],
+                                kwargs...)
     sinkstreamtypes = Data.streamtypes(Si)
     for sinkstreamtype in sinkstreamtypes
         if Data.streamtype(So, sinkstreamtype)
-            source_schema = Data.schema(source, sinkstreamtype)
+            source_schema = Data.schema(source)
             sink_schema, transforms2 = transform(source_schema, transforms)
-            sink = Si(sink_schema, sinkstreamtype, append, reference(source), args...; kwargs...)
-            return Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2)
-        end
-    end
-    throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
-end
-# for backwards compatibility
-Data.stream!{So, Si}(source::So, ::Type{Si}) = Data.stream!(source, Si, false, Dict{Int,Function}())
-
-function Data.stream!{So, Si}(source::So, sink::Si, append::Bool=false, transforms::Dict=Dict{Int,Function}())
-    sinkstreamtypes = Data.streamtypes(Si)
-    for sinkstreamtype in sinkstreamtypes
-        if Data.streamtype(So, sinkstreamtype)
-            source_schema = Data.schema(source, sinkstreamtype)
-            sink_schema, transforms2 = transform(source_schema, transforms)
-            sink = Si(sink, sink_schema, sinkstreamtype, append, reference(source))
-            return Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2)
+            sink = Si(sink_schema, sinkstreamtype, append, args...; kwargs...)
+            return Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
         end
     end
     throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
 end
 
-function streamto!{T, TT}(sink, ::Type{Data.Field}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
-    val = f(Data.streamfrom(source, Data.Field, T, row, col))
-    return Data.streamto!(sink, Data.Field, val, row, col, sch)
+function Data.stream!{So, Si}(source::So, sink::Si;
+                                append::Bool=false,
+                                transforms::Dict=Dict{Int,Function}(),
+                                filter::Function=TRUE,
+                                columns::Vector=[])
+    sinkstreamtypes = Data.streamtypes(Si)
+    for sinkstreamtype in sinkstreamtypes
+        if Data.streamtype(So, sinkstreamtype)
+            source_schema = Data.schema(source)
+            sink_schema, transforms2 = transform(source_schema, transforms)
+            sink = Si(sink, sink_schema, sinkstreamtype, append)
+            return Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
+        end
+    end
+    throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
+end
+
+# internal streaming machinery
+function generate_inner_loop(knownrows)
+    if !knownrows
+        return quote
+            while true
+                @inbounds for col = 1:cols
+                    # println("streaming with unknown rows, row = $row, col = $col...")
+                    Data.streamto!(sink, Data.Row, source, sourcetypes[col], sinktypes[col], row, col, sink_schema, transforms[col])
+                end
+                row += 1
+                Data.isdone(source, row, cols) && break
+            end
+            Data.setrows!(source, row - 1)
+        end
+    else
+        return quote
+            @inbounds for row = 1:rows, col = 1:cols
+                # println("streaming with known rows, sinkrows = $sinkrows, row = $row, col = $col...")
+                Data.streamto!(sink, Data.Row, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
+            end
+        end
+    end
+end
+
+@generated function Data.stream!{So, Si, R1, R2, T1, T2}(source::So, ::Type{Data.Row}, sink::Si,
+    source_schema::Schema{R1, T1}, sink_schema::Schema{R2, T2},
+    transforms, filter, columns)
+    return quote
+        Data.isdone(source, 1, 1) && return sink
+        rows, cols = size(source_schema)
+        sinkrows = max(0, size(sink_schema, 1) - rows)
+        sourcetypes = $(Tuple(T1.parameters))
+        sinktypes = $(Tuple(T2.parameters))
+        row = 1
+        try
+            $(generate_inner_loop(R1))
+        catch e
+            Data.cleanup!(sink)
+            rethrow(e)
+        end
+        return sink
+    end
+end
+
+function streamto!{T, TT}(sink, ::Type{Data.Row}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
+    val = f(Data.streamfrom(source, Data.Row, T, row, col))
+    # println("streamed val = $val")
+    return Data.streamto!(sink, Data.Row, val, row, col, sch)
 end
 streamto!{T <: StreamType}(sink, ::Type{T}, val, row, col, sch) = streamto!(sink, T, val, row, col)
 
-# Generic Data.stream! method for Data.Field
-function Data.stream!{T1, T2}(source::T1, ::Type{Data.Field}, sink::T2, source_schema::Schema{true}, sink_schema, transforms)
-    Data.isdone(source, 1, 1) && return sink
-    rows, cols = size(source_schema)
-    sinkrows = max(0, size(sink_schema, 1) - rows)
-    sourcetypes = Data.types(source_schema)
-    sinktypes = Data.types(sink_schema)
-    try
-        @inbounds for row = 1:rows, col = 1:cols
-            Data.streamto!(sink, Data.Field, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
-        end
-    catch e
-        Data.cleanup!(sink)
-        rethrow(e)
-    end
-    return sink
-end
-function Data.stream!{T1, T2}(source::T1, ::Type{Data.Field}, sink::T2, source_schema::Schema{false}, sink_schema, transforms)
-    Data.isdone(source, 1, 1) && return sink
-    rows, cols = size(source_schema)
-    sourcetypes = Data.types(source_schema)
-    sinktypes = Data.types(sink_schema)
-    row = 1
-    try
-        while true
-            @inbounds for col = 1:cols
-                Data.streamto!(sink, Data.Field, source, sourcetypes[col], sinktypes[col], row, col, sink_schema, transforms[col])
-            end
-            row += 1
-            Data.isdone(source, row, cols) && break
-        end
-        Data.setrows!(source, row - 1)
-    catch e
-        Data.cleanup!(sink)
-        rethrow(e)
-    end
-    return sink
+function streamto!{T, TT}(sink, ::Type{Data.Batch}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
+    column = f(Data.streamfrom(source, Data.Batch, T, col)::T)::TT
+    return streamto!(sink, Data.Batch, column, row, col, sch)
 end
 
-function streamto!{T, TT}(sink, ::Type{Data.Column}, source, ::Type{T}, ::Type{TT}, row, col, sch, f)
-    column = f(Data.streamfrom(source, Data.Column, T, col)::T)::TT
-    return streamto!(sink, Data.Column, column, row, col, sch)
-end
-
-function Data.stream!{T1, T2}(source::T1, ::Type{Data.Column}, sink::T2, source_schema, sink_schema, transforms)
+function Data.stream!{T1, T2}(source::T1, ::Type{Data.Batch}, sink::T2, source_schema, sink_schema, transforms)
     Data.isdone(source, 1, 1) && return sink
     rows, cols = size(source_schema)
     sinkrows = max(0, size(sink_schema, 1) - rows)
@@ -228,11 +223,11 @@ function Data.stream!{T1, T2}(source::T1, ::Type{Data.Column}, sink::T2, source_
     row = cur_row = 0
     try
         @inbounds for col = 1:cols
-            row = Data.streamto!(sink, Data.Column, source, sourcetypes[col], sinktypes[col], sinkrows + cur_row, col, sink_schema, transforms[col])
+            row = Data.streamto!(sink, Data.Batch, source, sourcetypes[col], sinktypes[col], sinkrows + cur_row, col, sink_schema, transforms[col])
         end
         while !Data.isdone(source, row+1, cols)
             @inbounds for col = 1:cols
-                cur_row = Data.streamto!(sink, Data.Column, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
+                cur_row = Data.streamto!(sink, Data.Batch, source, sourcetypes[col], sinktypes[col], sinkrows + row, col, sink_schema, transforms[col])
             end
             row += cur_row
         end
@@ -242,120 +237,6 @@ function Data.stream!{T1, T2}(source::T1, ::Type{Data.Column}, sink::T2, source_
         rethrow(e)
     end
     return sink
-end
-
-# DataFrames DataStreams definitions
-using DataFrames, NullableArrays, CategoricalArrays, WeakRefStrings
-
-# DataFrames DataStreams implementation
-function Data.schema(df::DataFrame, ::Type{Data.Column})
-    return Data.Schema(map(string, names(df)),
-            DataType[typeof(A) for A in df.columns], size(df, 1))
-end
-
-# DataFrame as a Data.Source
-function Data.isdone(source::DataFrame, row, col)
-    rows, cols = size(source)
-    return row > rows || col > cols
-end
-
-Data.streamtype(::Type{DataFrame}, ::Type{Data.Column}) = true
-Data.streamtype(::Type{DataFrame}, ::Type{Data.Field}) = true
-
-Data.streamfrom{T <: AbstractVector}(source::DataFrame, ::Type{Data.Column}, ::Type{T}, col) = (@inbounds A = source.columns[col]::T; return A)
-Data.streamfrom{T}(source::DataFrame, ::Type{Data.Column}, ::Type{T}, col) = (@inbounds A = source.columns[col]; return A)
-Data.streamfrom{T}(source::DataFrame, ::Type{Data.Field}, ::Type{T}, row, col) = (@inbounds A = Data.streamfrom(source, Data.Column, T, col); return A[row]::T)
-
-# DataFrame as a Data.Sink
-allocate{T}(::Type{T}, rows, ref) = Array{T}(rows)
-allocate{T}(::Type{Vector{T}}, rows, ref) = Array{T}(rows)
-
-allocate{T}(::Type{Nullable{T}}, rows, ref) = NullableArray{T, 1}(Array{T}(rows), fill(true, rows), isempty(ref) ? UInt8[] : ref)
-allocate{T}(::Type{NullableVector{T}}, rows, ref) = NullableArray{T, 1}(Array{T}(rows), fill(true, rows), isempty(ref) ? UInt8[] : ref)
-
-allocate{S,R}(::Type{CategoricalArrays.CategoricalValue{S,R}}, rows, ref) = CategoricalArray{S,1,R}(rows)
-allocate{S,R}(::Type{CategoricalVector{S,R}}, rows, ref) = CategoricalArray{S,1,R}(rows)
-
-allocate{S,R}(::Type{Nullable{CategoricalArrays.CategoricalValue{S,R}}}, rows, ref) = NullableCategoricalArray{S,1,R}(rows)
-allocate{S,R}(::Type{NullableCategoricalVector{S,R}}, rows, ref) = NullableCategoricalArray{S,1,R}(rows)
-
-if isdefined(Main, :DataArray)
-    allocate{T}(::Type{DataVector{T}}, rows, ref) = DataArray{T}(rows)
-end
-
-function DataFrame{T <: Data.StreamType}(sch::Data.Schema, ::Type{T}=Data.Field, append::Bool=false, ref::Vector{UInt8}=UInt8[], args...)
-    rows, cols = size(sch)
-    rows = max(0, T <: Data.Column ? 0 : rows) # don't pre-allocate for Column streaming
-    columns = Vector{Any}(cols)
-    types = Data.types(sch)
-    for i = 1:cols
-        columns[i] = allocate(types[i], rows, ref)
-    end
-    return DataFrame(columns, map(Symbol, Data.header(sch)))
-end
-
-# given an existing DataFrame (`sink`), make any necessary changes for streaming source
-# with Data.Schema `sch` to it, given we know if we'll be `appending` or not
-function DataFrame(sink, sch::Data.Schema, ::Type{Field}, append::Bool, ref::Vector{UInt8})
-    rows, cols = size(sch)
-    newsize = max(0, rows) + (append ? size(sink, 1) : 0)
-    # need to make sure we don't break a NullableVector{WeakRefString{UInt8}} when appending
-    if append
-        for (i, T) in enumerate(Data.types(sch))
-            if T <: Nullable{WeakRefString{UInt8}}
-                sink.columns[i] = NullableArray(String[string(get(x, "")) for x in sink.columns[i]])
-                sch.types[i] = Nullable{String}
-            end
-        end
-    end
-    newsize != size(sink, 1) && foreach(x->resize!(x, newsize), sink.columns)
-    sch.rows = newsize
-    return sink
-end
-function DataFrame(sink, sch::Schema, ::Type{Column}, append::Bool, ref::Vector{UInt8})
-    rows, cols = size(sch)
-    append ? (sch.rows += size(sink, 1)) : foreach(empty!, sink.columns)
-    return sink
-end
-
-Data.streamtypes(::Type{DataFrame}) = [Data.Column, Data.Field]
-
-Data.streamto!{T}(sink::DataFrame, ::Type{Data.Field}, val::T, row, col, sch::Data.Schema{false}) = push!(sink.columns[col]::Vector{T}, val)
-Data.streamto!{T}(sink::DataFrame, ::Type{Data.Field}, val::Nullable{T}, row, col, sch::Data.Schema{false}) = push!(sink.columns[col]::NullableVector{T}, val)
-Data.streamto!{T, R}(sink::DataFrame, ::Type{Data.Field}, val::CategoricalValue{T, R}, row, col, sch::Data.Schema{false}) = push!(sink.columns[col]::CategoricalVector{T, R}, val)
-Data.streamto!{T, R}(sink::DataFrame, ::Type{Data.Field}, val::Nullable{CategoricalValue{T, R}}, row, col, sch::Data.Schema{false}) = push!(sink.columns[col]::NullableCategoricalVector{T, R}, val)
-
-Data.streamto!{T}(sink::DataFrame, ::Type{Data.Field}, val::T, row, col, sch::Data.Schema{true}) = (sink.columns[col]::Vector{T})[row] = val
-Data.streamto!{T}(sink::DataFrame, ::Type{Data.Field}, val::Nullable{T}, row, col, sch::Data.Schema{true}) = (sink.columns[col]::NullableVector{T})[row] = val
-Data.streamto!(sink::DataFrame, ::Type{Data.Field}, val::Nullable{WeakRefString{UInt8}}, row, col, sch::Data.Schema{true}) = (sink.columns[col][row] = val)
-Data.streamto!{T, R}(sink::DataFrame, ::Type{Data.Field}, val::CategoricalValue{T, R}, row, col, sch::Data.Schema{true}) = (sink.columns[col]::CategoricalVector{T, R})[row] = val
-Data.streamto!{T, R}(sink::DataFrame, ::Type{Data.Field}, val::Nullable{CategoricalValue{T, R}}, row, col, sch::Data.Schema{true}) = (sink.columns[col]::NullableCategoricalVector{T, R})[row] = val
-
-function Data.streamto!{T}(sink::DataFrame, ::Type{Data.Column}, column::T, row, col, sch::Data.Schema)
-    if row == 0
-        sink.columns[col] = column
-    else
-        append!(sink.columns[col]::T, column)
-    end
-    return length(column)
-end
-
-function Base.append!{T}(dest::NullableVector{WeakRefString{T}}, column::NullableVector{WeakRefString{T}})
-    offset = length(dest.values)
-    parentoffset = length(dest.parent)
-    append!(dest.isnull, column.isnull)
-    append!(dest.parent, column.parent)
-    # appending new data to `dest` would invalid all existing WeakRefString pointers
-    resize!(dest.values, length(dest) + length(column))
-    for i = 1:offset
-        old = dest.values[i]
-        dest.values[i] = WeakRefString{T}(pointer(dest.parent, old.ind), old.len, old.ind)
-    end
-    for i = 1:length(column)
-        old = column.values[i]
-        dest.values[offset + i] = WeakRefString{T}(pointer(dest.parent, parentoffset + old.ind), old.len, parentoffset + old.ind)
-    end
-    return length(dest)
 end
 
 end # module Data

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -116,7 +116,7 @@ Data.streamfrom(source, ::Type{Data.Column}, ::Type{T}, col::Int) where {T}
 """
 function streamfrom end
 Data.streamfrom(source, ::Type{S}, T, row, ::Type{Val{N}}) where {S <: StreamType, N} = Data.streamfrom(source, S, T, row, N)
-Data.streamfrom(source, ::Type{Data.Column}, T, row, col::Int) = Data.streamfrom(source, Data.Column, T, N)
+Data.streamfrom(source, ::Type{Data.Column}, T, row, col::Int) = Data.streamfrom(source, Data.Column, T, col)
 
 # Generic fallbacks
 Data.streamtype(source, ::Type{<:StreamType}) = false
@@ -279,6 +279,7 @@ function inner_loop(::Type{Val{N}}, ::Type{S}, ::Type{Val{homogenous}}, ::Type{T
             end
         end
     end
+    # println(macroexpand(loop))
     return loop
 end
 
@@ -302,7 +303,7 @@ function generate_loop(::Type{Val{knownrows}}, ::Type{S}, inner_loop) where {kno
             Data.setrows!(source, row)
         end
     end
-    # println(loop)
+    println(macroexpand(loop))
     return loop
 end
 
@@ -321,6 +322,7 @@ end
         rows, cols = size(source_schema)::Tuple{$RR, Int}
         Data.isdone(source, 1, 1, rows, cols) && return sink
         sourcetypes = $sourcetypes
+        N = $N
         try
             $(generate_loop(knownrows, S, inner_loop(N, S, homogeneous, T, knownrows)))
         catch e

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -1,0 +1,50 @@
+
+reload("DataStreams"); reload("Feather")
+source = Feather.Source("test.feather")
+sink = Si = NamedTuple
+transforms = Dict{Int,Function}()
+append = false
+args = kwargs = ()
+source_schema = DataStreams.Data.schema(source)
+sink_schema, transforms2 = DataStreams.Data.transform(source_schema, transforms, true);
+sinkstreamtype = DataStreams.Data.Column
+sink = Si(sink_schema, sinkstreamtype, append, args...; kwargs...);
+columns = []
+filter = x->true
+@code_warntype DataStreams.Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
+
+
+# mutable struct RowIterator{names,T}
+#     nt::NamedTuple{names, T}
+# end
+# Base.start(ri::RowIterator) = 1
+# @generated function Base.next(ri::RowIterator{names, T}, row::Int) where {names, T}
+#     S = Tuple{map(eltype, T.parameters)...}
+#     r = :(convert($S, tuple($((:($(Symbol("v$i")) = getfield(ri.nt, $i)[row]; $(Symbol("v$i")) isa Null ? null : $(Symbol("v$i"))) for i = 1:nfields(T))...))))
+#     return r
+# end
+# Base.done(ri::RowIterator, i::Int) = i > length(getfield(ri.nt, 1))
+# @generated function Base.next(ri::RowIterator{names,T}, row::Int) where {names, T}
+#     NT = NamedTuple{names}
+#     S = Tuple{map(eltype, T.parameters)...}
+#     r = :(Base.namedtuple($NT, convert($S, tuple($((:($(Symbol("v$i")) = getfield(ri.nt, $i)[row]; $(Symbol("v$i")) isa Null ? null : $(Symbol("v$i"))) for i = 1:nfields(T))...)))...))
+#     return r
+# end
+#
+# @generated function Base.next(ri::RowIterator{names,T,S}, i::Int)::S where {names, T, S}
+#     # NT = NamedTuple{names}
+#     args = Expr[:(v = getfield(nt, $i)[row]; ifelse(v isa Null, null, v)) for i = 1:nfields(T)]
+#     return :((args...))
+#     # R = NamedTuple{names, Tuple{map(eltype, T.parameters)...}}
+#     # return :(convert($R, Base.namedtuple($NT, $(args...))))
+# end
+# check codegen of:
+  # < 500 columns
+  # homogenous datasets > 500 columns
+  # > 500 columns
+
+  # Data.Field vs. Data.Column
+
+  # knownrows vs. not
+
+  #

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -14,6 +14,20 @@ filter = x->true
 @code_warntype DataStreams.Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
 
 
+source = ODBC.Source(dsn, "show databases")
+sink = Si = NamedTuple
+transforms = Dict{Int,Function}()
+append = false
+args = kwargs = ()
+source_schema = DataStreams.Data.schema(source)
+sink_schema, transforms2 = DataStreams.Data.transform(source_schema, transforms, true);
+sinkstreamtype = DataStreams.Data.Column
+sink = Si(sink_schema, sinkstreamtype, append, args...; kwargs...);
+columns = []
+filter = x->true
+@code_warntype DataStreams.Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
+
+
 # mutable struct RowIterator{names,T}
 #     nt::NamedTuple{names, T}
 # end

--- a/test/codegen.jl
+++ b/test/codegen.jl
@@ -27,31 +27,60 @@ columns = []
 filter = x->true
 @code_warntype DataStreams.Data.stream!(source, sinkstreamtype, sink, source_schema, sink_schema, transforms2, filter, columns)
 
+# DataStreams tests
+sink = Si = Sink
+transforms = Dict{Int,Function}()
+append = false
+args = kwargs = ()
+source_schema = DataStreams.Data.schema(source)
+sink_schema, transforms2 = DataStreams.Data.transform(source_schema, transforms, true);
+sinkstreamtype = DataStreams.Data.Field
+sink = Si(sink_schema, sinkstreamtype, append, args...; kwargs...);
+columns = []
+filter = x->true
+@code_warntype DataStreams.Data.stream!(source, sinkstreamtype, sink, source_schema, 0, transforms2, filter, columns)
 
-# mutable struct RowIterator{names,T}
-#     nt::NamedTuple{names, T}
-# end
-# Base.start(ri::RowIterator) = 1
-# @generated function Base.next(ri::RowIterator{names, T}, row::Int) where {names, T}
-#     S = Tuple{map(eltype, T.parameters)...}
-#     r = :(convert($S, tuple($((:($(Symbol("v$i")) = getfield(ri.nt, $i)[row]; $(Symbol("v$i")) isa Null ? null : $(Symbol("v$i"))) for i = 1:nfields(T))...))))
-#     return r
-# end
-# Base.done(ri::RowIterator, i::Int) = i > length(getfield(ri.nt, 1))
-# @generated function Base.next(ri::RowIterator{names,T}, row::Int) where {names, T}
-#     NT = NamedTuple{names}
-#     S = Tuple{map(eltype, T.parameters)...}
-#     r = :(Base.namedtuple($NT, convert($S, tuple($((:($(Symbol("v$i")) = getfield(ri.nt, $i)[row]; $(Symbol("v$i")) isa Null ? null : $(Symbol("v$i"))) for i = 1:nfields(T))...)))...))
-#     return r
-# end
-#
-# @generated function Base.next(ri::RowIterator{names,T,S}, i::Int)::S where {names, T, S}
-#     # NT = NamedTuple{names}
-#     args = Expr[:(v = getfield(nt, $i)[row]; ifelse(v isa Null, null, v)) for i = 1:nfields(T)]
-#     return :((args...))
-#     # R = NamedTuple{names, Tuple{map(eltype, T.parameters)...}}
-#     # return :(convert($R, Base.namedtuple($NT, $(args...))))
-# end
+
+# CSV
+reload("CSV")
+T = Int64
+@time source = CSV.Source("/Users/jacobquinn/Downloads/randoms_$(T).csv";)
+sink = Si = NamedTuple
+transforms = Dict{Int,Function}()
+append = false
+args = kwargs = ()
+source_schema = DataStreams.Data.schema(source)
+sink_schema, transforms2 = DataStreams.Data.transform(source_schema, transforms, true);
+sinkstreamtype = DataStreams.Data.Field
+sink = Si(sink_schema, sinkstreamtype, append, args...; kwargs...);
+columns = []
+filter = x->true
+@code_warntype DataStreams.Data.stream!(source, sinkstreamtype, sink, source_schema, 0, transforms2, filter, columns)
+
+mutable struct RowIterator{names,T}
+    nt::NamedTuple{names, T}
+end
+Base.start(ri::RowIterator) = 1
+@generated function Base.next(ri::RowIterator{names, T}, row::Int) where {names, T}
+    S = Tuple{map(eltype, T.parameters)...}
+    r = :(convert($S, tuple($((:($(Symbol("v$i")) = getfield(ri.nt, $i)[row]; $(Symbol("v$i")) isa Null ? null : $(Symbol("v$i"))) for i = 1:nfields(T))...))))
+    return r
+end
+Base.done(ri::RowIterator, i::Int) = i > length(getfield(ri.nt, 1))
+@generated function Base.next(ri::RowIterator{names,T}, row::Int) where {names, T}
+    NT = NamedTuple{names}
+    S = Tuple{map(eltype, T.parameters)...}
+    r = :(Base.namedtuple($NT, convert($S, tuple($((:($(Symbol("v$i")) = getfield(ri.nt, $i)[row]; $(Symbol("v$i")) isa Null ? null : $(Symbol("v$i"))) for i = 1:nfields(T))...)))...))
+    return r
+end
+
+@generated function Base.next(ri::RowIterator{names,T,S}, i::Int)::S where {names, T, S}
+    # NT = NamedTuple{names}
+    args = Expr[:(v = getfield(nt, $i)[row]; ifelse(v isa Null, null, v)) for i = 1:nfields(T)]
+    return :((args...))
+    # R = NamedTuple{names, Tuple{map(eltype, T.parameters)...}}
+    # return :(convert($R, Base.namedtuple($NT, $(args...))))
+end
 # check codegen of:
   # < 500 columns
   # homogenous datasets > 500 columns
@@ -62,3 +91,33 @@ filter = x->true
   # knownrows vs. not
 
   #
+
+  # test codegen based on # of columns
+
+
+
+function f(v::Vector{Int8}, n)
+  s = Int8(0)
+  @inbounds for i = 1:n
+    s += v[i]
+  end
+  return s
+end
+function f(v::Vector{Union{Void, Int8}}, n)
+  s = Int8(0)
+  @inbounds for i = 1:n
+    t = Base.arrayref(v, i)
+    s += t isa Void ? Int8(0) : t
+  end
+  return s
+end
+using BenchmarkTools
+n = 100
+@benchmark f($(Vector{Int8}(n)), $n)
+V = Vector{Union{Void, Int8}}(n)
+@benchmark f($(V), $n)
+@code_llvm f(Vector{Int8}(10), 10)
+@code_llvm f(Vector{Union{Void, Int8}}(10), 10)
+function f(v)
+  return Base.arrayref(v, 1)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,9 @@
 using Base.Test, DataStreams, Nulls
 
-if isdefined(Core, :NamedTuple)
+import Base: ==
+==(a::DataStreams.Data.Schema, b::DataStreams.Data.Schema) = DataStreams.Data.types(a) == DataStreams.Data.types(b) && DataStreams.Data.header(a) == DataStreams.Data.header(b) && size(a) == size(b)
+
+@static if isdefined(Core, :NamedTuple)
 
 mutable struct Source{T}
     sch::DataStreams.Data.Schema
@@ -15,9 +18,6 @@ DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Field}, ::Type{T}
 mutable struct Sink{T}
     nt::T
 end
-
-import Base: ==
-==(a::DataStreams.Data.Schema, b::DataStreams.Data.Schema) = DataStreams.Data.types(a) == DataStreams.Data.types(b) && DataStreams.Data.header(a) == DataStreams.Data.header(b) && size(a) == size(b)
 
 I = (id = Int64[1, 2, 3, 4, 5],
 firstname = (Union{String, Null})["Benjamin", "Wayne", "Sean", "Charles", null],
@@ -154,7 +154,7 @@ sch2, trans = DataStreams.Data.transform(sch, Dict("col1"=>sin), false)
 
 end # @testset "Data.transform"
 
-if isdefined(Core, :NamedTuple)
+@static if isdefined(Core, :NamedTuple)
 
 @testset "Data.stream!" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,54 +1,300 @@
-using Base.Test, DataStreams, DataFrames, NullableArrays
+using Base.Test, DataStreams, Nulls, WeakRefStrings
 
-if !isdefined(Core, :String)
-    typealias String UTF8String
+@testset "DataStreams" begin
+
+@testset "Data.Schema" begin
+
+sch = DataStreams.Data.Schema()
+@test size(sch) == (0, 0)
+@test DataStreams.Data.header(sch) == String[]
+@test DataStreams.Data.types(sch) == ()
+
+sch = DataStreams.Data.Schema((Int,))
+@test size(sch) == (0, 1)
+@test DataStreams.Data.header(sch) == String["Column1"]
+@test DataStreams.Data.types(sch) == (Int,)
+
+sch = DataStreams.Data.Schema([Int])
+@test size(sch) == (0, 1)
+@test DataStreams.Data.header(sch) == String["Column1"]
+@test DataStreams.Data.types(sch) == (Int,)
+
+sch = DataStreams.Data.Schema((Int,), ["col1"])
+@test size(sch) == (0, 1)
+@test DataStreams.Data.header(sch) == String["col1"]
+@test DataStreams.Data.types(sch) == (Int,)
+
+@test_throws ArgumentError DataStreams.Data.Schema((String,), ["col1", "col2"])
+
+getR(::DataStreams.Data.Schema{R}) where {R} = R
+getT(::DataStreams.Data.Schema{R, T}) where {R, T} = T
+
+sch = DataStreams.Data.Schema((Int,), ["col1"], 1)
+@test size(sch) == (1, 1)
+@test DataStreams.Data.header(sch) == String["col1"]
+@test DataStreams.Data.types(sch) == (Int,)
+@test getR(sch) == true
+@test getT(sch) == Tuple{Int}
+
+sch = DataStreams.Data.Schema((String,), ["col1"], null)
+@test size(sch) == (null, 1)
+@test DataStreams.Data.header(sch) == String["col1"]
+@test DataStreams.Data.types(sch) == (String,)
+@test getR(sch) == false
+@test getT(sch) == Tuple{String}
+
+@test_throws ArgumentError DataStreams.Data.Schema((String,), ["col1"], -1)
+
+sch = DataStreams.Data.Schema((Int,), ["col1"], 0, Dict("hey"=>"ho"))
+@test size(sch) == (0, 1)
+@test DataStreams.Data.header(sch) == String["col1"]
+@test DataStreams.Data.types(sch) == (Int,)
+@test DataStreams.Data.metadata(sch) == Dict("hey"=>"ho")
+
+sch = DataStreams.Data.Schema((Int,), ["col1"])
+@test sch["col1"] == 1
+
+end # @testset "Data.Schema"
+
+import Base: ==
+==(a::DataStreams.Data.Schema, b::DataStreams.Data.Schema) = DataStreams.Data.types(a) == DataStreams.Data.types(b) && DataStreams.Data.header(a) == DataStreams.Data.header(b) && size(a) == size(b)
+
+@testset "Data.transform" begin
+
+# knownrows vs. not
+sch = DataStreams.Data.Schema((Int,), ["col1"], 1)
+sch2, trans = DataStreams.Data.transform(sch, Dict{Int, Function}(), true)
+@test sch == sch2
+@test trans == (identity,)
+
+sch = DataStreams.Data.Schema((Int, Float64, String,), ["col1", "col2", "col3"], null)
+sch2, trans = DataStreams.Data.transform(sch, Dict{Int, Function}(), true)
+@test sch == sch2
+@test trans == (identity, identity, identity)
+
+sch = DataStreams.Data.Schema((Int,), ["col1"], 1)
+f = x->string(x)
+sch2, trans = DataStreams.Data.transform(sch, Dict(1=>f), true)
+@test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
+@test DataStreams.Data.types(sch2) == (String,)
+@test trans == (f,)
+
+sch = DataStreams.Data.Schema((Int, Float64, WeakRefString{UInt8}), ["col1", "col2", "col3"], null)
+f = x->parse(Int, x)
+sch2, trans = DataStreams.Data.transform(sch, Dict("col3"=>f), true)
+@test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
+@test DataStreams.Data.types(sch2) == (Int, Float64, Int)
+@test trans == (identity, identity, f)
+
+sch = DataStreams.Data.Schema((Int, Float64, WeakRefString{UInt8}), ["col1", "col2", "col3"], null)
+sch2, trans = DataStreams.Data.transform(sch, Dict{Int, Function}(), false)
+@test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
+@test DataStreams.Data.types(sch2) == (Int, Float64, String)
+@test trans == (identity, identity, identity)
+
+sch = DataStreams.Data.Schema((?WeakRefString{UInt8},), ["col1"])
+sch2, trans = DataStreams.Data.transform(sch, Dict{Int, Function}(), false)
+@test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
+@test DataStreams.Data.types(sch2) == (?String,)
+@test trans == (identity,)
+
+sch = DataStreams.Data.Schema((Int,), ["col1"], 1)
+sch2, trans = DataStreams.Data.transform(sch, Dict("col1"=>sin), false)
+@test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
+@test DataStreams.Data.types(sch2) == (Float64,)
+@test trans == (sin,)
+
+end # @testset "Data.transform"
+
+mutable struct Source{T}
+    sch::DataStreams.Data.Schema
+    nt::T
 end
+DataStreams.Data.schema(s::Source) = s.sch
+DataStreams.Data.isdone(s::Source, row, col, rows, cols) = col > cols || (isnull(rows) ? row > length(s.nt[col]) : row > rows)
+DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Column}, ::Type{T}, row, col) where {T} = s.nt[col]
+DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Field}, ::Type{T}, row, col) where {T} = s.nt[col][row]
 
-ROWS = 2
-COLS = 3
+I = (id = Int64[1, 2, 3, 4, 5],
+     firstname = (?String)["Benjamin", "Wayne", "Sean", "Charles", null],
+     lastname = String["Chavez", "Burke", "Richards", "Long", "Rose"],
+     salary = (?Float64)[null, 46134.1, 45046.2, 30555.6, 88894.1],
+     rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
+     hired = (?Date)[Date("2011-07-07"), Date("2016-02-19"), null, Date("2002-01-05"), Date("2008-05-15")],
+     fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"), DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"), DateTime("2007-09-29T12:09:00")]
+)
+J = (; :_0=>["0"], (Symbol("_$i")=>[i] for i = 1:501)...);
+K = (; (Symbol("_$i")=>[i] for i = 1:501)...);
 
-sch = Data.Schema([Int, Int, Int], ROWS)
-data = [ 1 2 ; 10 20 ]
+nms(::NamedTuple{names}) where {names} = names
+I_L = Source(DataStreams.Data.Schema(collect(map(eltype, I)), nms(I), 5), I);
+I_M = Source(DataStreams.Data.Schema(collect(map(eltype, I)), nms(I), null), I);
 
-@test Data.header(sch) == String["Column1", "Column2", "Column3"]
-@test Data.types(sch) == [Int, Int, Int]
-@test size(sch) == (ROWS, COLS)
+J_L = Source(DataStreams.Data.Schema(collect(map(eltype, J)), nms(J), 1), J);
+J_M = Source(DataStreams.Data.Schema(collect(map(eltype, J)), nms(J), null), J);
 
-"""
-A generic `Sink` type that fulfills the DataStreams interface
-wraps any kind of Julia structure `T`; by default `T` = Vector{NullableVector}
-"""
-type TableSink{T} <: Data.Sink
-    schema::Data.Schema
-    data::T
-    other::Any # for other metadata, references, etc.
+K_L = Source(DataStreams.Data.Schema(collect(map(eltype, K)), nms(K), 1), K);
+K_M = Source(DataStreams.Data.Schema(collect(map(eltype, K)), nms(K), null), K);
+
+mutable struct Sink{T}
+    nt::T
 end
+Sink(sch::DataStreams.Data.Schema, S, append, args...; reference::Vector{UInt8}=UInt8[]) = Sink(NamedTuple(sch, S, append, args...; reference=reference))
+(::Type{T})(sink, sch::DataStreams.Data.Schema, S, append; reference::Vector{UInt8}=UInt8[]) where {T <: Sink} = Sink(NamedTuple(sink.nt, sch, S, append; reference=reference))
+DataStreams.Data.streamtypes(::Type{<:Sink}) = [DataStreams.Data.Column, DataStreams.Data.Field]
+DataStreams.Data.weakrefstrings(::Type{<:Sink}) = true
+DataStreams.Data.streamto!(sink::Sink, ::Type{DataStreams.Data.Field}, val, row, col) =
+    (C = getfield(sink.nt, col); row > length(C) ? push!(C, val) : setindex!(C, val, row); return)
+DataStreams.Data.streamto!(sink::Sink, ::Type{DataStreams.Data.Column}, column, col) =
+    append!(getfield(sink.nt, col), column)
 
-function TableSink(sch::Data.Schema)
-    rows, cols = size(sch)
-    TableSink(sch, NullableVector[NullableArray(T, rows) for T in Data.types(sch)], 0)
-end
+@testset "Data.stream!" begin
 
-TableSink(s::Data.Source) = TableSink(schema(s))
+### ALL PAIRS TESTING
 
-import DataStreams.Data.stream!
+# constructed Sink vs. constructed on-the-fly: A, B
+# append vs. not; C, D
+# w/ transform functions vs. not: E, F
+# Data.Field vs. Data.Column: G, H
+# <500, >500, homogenous types code path: I, J, K
+# knownrows vs. not: L, M
 
-function Data.stream!(src::DataFrame, snk::TableSink)
-    # TODO: this could be improved considering different source Schema.
-    snk.data = src.columns
-end
+# incompatible source => constructed Sink
+@test_throws ArgumentError DataStreams.Data.stream!(I_L, Sink(I))
 
-src_tb = DataFrame()
-snk = TableSink(sch)
+# incompatible source => otf Sink
+@test_throws ArgumentError DataStreams.Data.stream!(I_L, Sink, I)
 
-snk_tb = Data.stream!(src_tb, snk)
+## Data.Field
+DataStreams.Data.streamtype(::Type{<:Source}, ::Type{DataStreams.Data.Field}) = true
+# A, C, E, G, I, L: append to constructed Sink w/ transforms via Data.Field w/ Source=I_J
+source = I_L
+sink = Sink(deepcopy(I))
+transforms = Dict(1=>x->x+1)
+DataStreams.Data.stream!(source, sink; append=true, transforms=transforms)
 
-schema = Data.Schema(["A", "B"], [Int64, String])
-transforms = Dict{String, Function}("A" => (x) -> -x, "B" => lowercase)
-sink_schema, transforms2 = Data.transform(schema, transforms)
-@test transforms2 == [transforms["A"], transforms["B"]]
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (10, 7)
+@test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired"]
+@test DataStreams.Data.types(sch) == (Int64, ?String, String, ?Float64, Float64, ?Date, DateTime)
+@test sink.nt.id == [1,2,3,4,5,2,3,4,5,6]
 
-schema = Data.Schema(["A", "B"], [Int64, String])
-transforms = Dict{String, Function}("B" => lowercase)
-sink_schema, transforms2 = Data.transform(schema, transforms)
-@test transforms2 == [identity, transforms["B"]]
+# A, C, F, G, J, L: append to constructed Sink w/o transforms via Data.Field w/ Source=J_L
+source = J_L;
+sink = Sink(deepcopy(J));
+Data.stream!(source, sink; append=true);
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (2, 502)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 0:501)
+@test DataStreams.Data.types(sch) == (String, (Int for i = 1:501)...)
+@test sink.nt._0 == ["0", "0"]
+@test sink.nt._1 == [1, 1]
+
+# A, D, F, G, J, M: replace constructed Sink w/o transforms via Data.Field w/ Source=J_M
+source = J_M;
+sink = Sink(deepcopy(J));
+Data.stream!(source, sink)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (1, 502)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 0:501)
+@test DataStreams.Data.types(sch) == (String, (Int for i = 1:501)...)
+@test sink.nt._0 == ["0"]
+@test sink.nt._1 == [1]
+
+# B, D, E, G, J, L: replace otf Sink w/ transforms via Data.Field w/ Source=J_L
+source = J_L
+sink = Sink(deepcopy(J))
+transforms = Dict(2=>x->x+1)
+Data.stream!(source, Sink, sink.nt; transforms=transforms)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (1, 502)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 0:501)
+@test DataStreams.Data.types(sch) == (String, (Int for i = 1:501)...)
+@test sink.nt._0 == ["0"]
+@test sink.nt._1 == [2]
+
+# B, D, E, G, K, L: replace otf Sink w/ transforms via Data.Field w/ Source=K_L
+source = K_L
+sink = Sink(deepcopy(K))
+transforms = Dict(2=>x->x+1)
+Data.stream!(source, Sink, sink.nt; transforms=transforms)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (1, 501)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 1:501)
+@test DataStreams.Data.types(sch) == ((Int for i = 1:501)...)
+@test sink.nt._1 == [1]
+@test sink.nt._2 == [3]
+
+## Data.Column
+# A, D, E, H, K, M: replace constructed Sink w/ transforms via Data.Column w/ Source=K_M
+DataStreams.Data.streamtype(::Type{<:Source}, ::Type{DataStreams.Data.Column}) = true
+source = K_M
+sink = Sink(deepcopy(K))
+transforms = Dict(2=>x->x+1)
+Data.stream!(source, sink; transforms=transforms)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (1, 501)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 1:501)
+@test DataStreams.Data.types(sch) == ((Int for i = 1:501)...)
+@test sink.nt._1 == [1]
+@test sink.nt._2 == [3]
+
+# B, C, F, H, K, M: append to otf Sink w/o transforms via Data.Column w/ Source=K_M
+source = K_M
+sink = Sink(deepcopy(K))
+Data.stream!(source, Sink, sink.nt; append=true)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (2, 501)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 1:501)
+@test DataStreams.Data.types(sch) == ((Int for i = 1:501)...)
+@test sink.nt._1 == [1, 1]
+@test sink.nt._2 == [2, 2]
+
+# B, D, F, H, I, M: replace otf Sink w/o transforms via Data.Column w/ Source=I_M
+source = I_M
+sink = Sink(deepcopy(I))
+transforms = Dict()
+Data.stream!(source, Sink, sink.nt)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (5, 7)
+@test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired"]
+@test DataStreams.Data.types(sch) == (Int64, ?String, String, ?Float64, Float64, ?Date, DateTime)
+@test sink.nt.id == [1,2,3,4,5]
+
+# B, D, F, H, I, L: replace otf Sink w/o transforms via Data.Column w/ Source=I_L
+source = I_L
+sink = Sink(deepcopy(I))
+Data.stream!(source, Sink, sink.nt)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (5, 7)
+@test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired"]
+@test DataStreams.Data.types(sch) == (Int64, ?String, String, ?Float64, Float64, ?Date, DateTime)
+@test sink.nt.id == [1,2,3,4,5]
+
+# B, D, E, H, J, L: replace otf Sink w/ transforms via Data.Field w/ Source=J_L
+source = J_L
+sink = Sink(deepcopy(J))
+transforms = Dict(2=>x->x+1)
+Data.stream!(source, Sink, sink.nt; transforms=transforms)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (1, 502)
+@test DataStreams.Data.header(sch) == collect("_$i" for i = 0:501)
+@test DataStreams.Data.types(sch) == (String, (Int for i = 1:501)...)
+@test sink.nt._0 == ["0"]
+@test sink.nt._1 == [2]
+
+end # @testset "Data.stream!"
+
+# @testset "DataStreams NamedTuple" begin
+#
+# end
+end # @testset "DataStreams"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,28 @@
-using Base.Test, DataStreams, Nulls, WeakRefStrings
+using Base.Test, DataStreams, Nulls
+
+mutable struct Source{T}
+    sch::DataStreams.Data.Schema
+    nt::T
+end
+
+DataStreams.Data.schema(s::Source) = s.sch
+DataStreams.Data.isdone(s::Source, row, col, rows, cols) = col > cols || (isnull(rows) ? row > length(s.nt[col]) : row > rows)
+DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Column}, ::Type{T}, row, col) where {T} = s.nt[col]
+DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Field}, ::Type{T}, row, col) where {T} = s.nt[col][row]
+
+mutable struct Sink{T}
+    nt::T
+end
+
+import Base: ==
+==(a::DataStreams.Data.Schema, b::DataStreams.Data.Schema) = DataStreams.Data.types(a) == DataStreams.Data.types(b) && DataStreams.Data.header(a) == DataStreams.Data.header(b) && size(a) == size(b)
 
 @testset "DataStreams" begin
 
 @testset "Data.Schema" begin
 
 sch = DataStreams.Data.Schema()
+@show size(sch)
 @test size(sch) == (0, 0)
 @test DataStreams.Data.header(sch) == String[]
 @test DataStreams.Data.types(sch) == ()
@@ -56,9 +74,6 @@ sch = DataStreams.Data.Schema((Int,), ["col1"])
 
 end # @testset "Data.Schema"
 
-import Base: ==
-==(a::DataStreams.Data.Schema, b::DataStreams.Data.Schema) = DataStreams.Data.types(a) == DataStreams.Data.types(b) && DataStreams.Data.header(a) == DataStreams.Data.header(b) && size(a) == size(b)
-
 @testset "Data.transform" begin
 
 # knownrows vs. not
@@ -79,23 +94,23 @@ sch2, trans = DataStreams.Data.transform(sch, Dict(1=>f), true)
 @test DataStreams.Data.types(sch2) == (String,)
 @test trans == (f,)
 
-sch = DataStreams.Data.Schema((Int, Float64, WeakRefString{UInt8}), ["col1", "col2", "col3"], null)
+sch = DataStreams.Data.Schema((Int, Float64, String), ["col1", "col2", "col3"], null)
 f = x->parse(Int, x)
 sch2, trans = DataStreams.Data.transform(sch, Dict("col3"=>f), true)
 @test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
 @test DataStreams.Data.types(sch2) == (Int, Float64, Int)
 @test trans == (identity, identity, f)
 
-sch = DataStreams.Data.Schema((Int, Float64, WeakRefString{UInt8}), ["col1", "col2", "col3"], null)
+sch = DataStreams.Data.Schema((Int, Float64, String), ["col1", "col2", "col3"], null)
 sch2, trans = DataStreams.Data.transform(sch, Dict{Int, Function}(), false)
 @test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
 @test DataStreams.Data.types(sch2) == (Int, Float64, String)
 @test trans == (identity, identity, identity)
 
-sch = DataStreams.Data.Schema((?WeakRefString{UInt8},), ["col1"])
+sch = DataStreams.Data.Schema((Union{String, Null},), ["col1"])
 sch2, trans = DataStreams.Data.transform(sch, Dict{Int, Function}(), false)
 @test DataStreams.Data.header(sch) == DataStreams.Data.header(sch2)
-@test DataStreams.Data.types(sch2) == (?String,)
+@test DataStreams.Data.types(sch2) == (Union{String, Null},)
 @test trans == (identity,)
 
 sch = DataStreams.Data.Schema((Int,), ["col1"], 1)
@@ -106,21 +121,12 @@ sch2, trans = DataStreams.Data.transform(sch, Dict("col1"=>sin), false)
 
 end # @testset "Data.transform"
 
-mutable struct Source{T}
-    sch::DataStreams.Data.Schema
-    nt::T
-end
-DataStreams.Data.schema(s::Source) = s.sch
-DataStreams.Data.isdone(s::Source, row, col, rows, cols) = col > cols || (isnull(rows) ? row > length(s.nt[col]) : row > rows)
-DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Column}, ::Type{T}, row, col) where {T} = s.nt[col]
-DataStreams.Data.streamfrom(s::Source, ::Type{DataStreams.Data.Field}, ::Type{T}, row, col) where {T} = s.nt[col][row]
-
 I = (id = Int64[1, 2, 3, 4, 5],
-     firstname = (?String)["Benjamin", "Wayne", "Sean", "Charles", null],
+     firstname = (Union{String, Null})["Benjamin", "Wayne", "Sean", "Charles", null],
      lastname = String["Chavez", "Burke", "Richards", "Long", "Rose"],
-     salary = (?Float64)[null, 46134.1, 45046.2, 30555.6, 88894.1],
+     salary = (Union{Float64, Null})[null, 46134.1, 45046.2, 30555.6, 88894.1],
      rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
-     hired = (?Date)[Date("2011-07-07"), Date("2016-02-19"), null, Date("2002-01-05"), Date("2008-05-15")],
+     hired = (Union{Date, Null})[Date("2011-07-07"), Date("2016-02-19"), null, Date("2002-01-05"), Date("2008-05-15")],
      fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"), DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"), DateTime("2007-09-29T12:09:00")]
 )
 J = (; :_0=>["0"], (Symbol("_$i")=>[i] for i = 1:501)...);
@@ -136,9 +142,6 @@ J_M = Source(DataStreams.Data.Schema(collect(map(eltype, J)), nms(J), null), J);
 K_L = Source(DataStreams.Data.Schema(collect(map(eltype, K)), nms(K), 1), K);
 K_M = Source(DataStreams.Data.Schema(collect(map(eltype, K)), nms(K), null), K);
 
-mutable struct Sink{T}
-    nt::T
-end
 Sink(sch::DataStreams.Data.Schema, S, append, args...; reference::Vector{UInt8}=UInt8[]) = Sink(NamedTuple(sch, S, append, args...; reference=reference))
 (::Type{T})(sink, sch::DataStreams.Data.Schema, S, append; reference::Vector{UInt8}=UInt8[]) where {T <: Sink} = Sink(NamedTuple(sink.nt, sch, S, append; reference=reference))
 DataStreams.Data.streamtypes(::Type{<:Sink}) = [DataStreams.Data.Column, DataStreams.Data.Field]
@@ -176,7 +179,7 @@ DataStreams.Data.stream!(source, sink; append=true, transforms=transforms)
 sch = DataStreams.Data.schema(sink.nt)
 @test size(sch) == (10, 7)
 @test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired"]
-@test DataStreams.Data.types(sch) == (Int64, ?String, String, ?Float64, Float64, ?Date, DateTime)
+@test DataStreams.Data.types(sch) == (Int64, Union{String, Null}, String, Union{Float64, Null}, Float64, Union{Date, Null}, DateTime)
 @test sink.nt.id == [1,2,3,4,5,2,3,4,5,6]
 
 # A, C, F, G, J, L: append to constructed Sink w/o transforms via Data.Field w/ Source=J_L
@@ -265,7 +268,7 @@ Data.stream!(source, Sink, sink.nt)
 sch = DataStreams.Data.schema(sink.nt)
 @test size(sch) == (5, 7)
 @test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired"]
-@test DataStreams.Data.types(sch) == (Int64, ?String, String, ?Float64, Float64, ?Date, DateTime)
+@test DataStreams.Data.types(sch) == (Int64, Union{String, Null}, String, Union{Float64, Null}, Float64, Union{Date, Null}, DateTime)
 @test sink.nt.id == [1,2,3,4,5]
 
 # B, D, F, H, I, L: replace otf Sink w/o transforms via Data.Column w/ Source=I_L
@@ -276,7 +279,7 @@ Data.stream!(source, Sink, sink.nt)
 sch = DataStreams.Data.schema(sink.nt)
 @test size(sch) == (5, 7)
 @test DataStreams.Data.header(sch) == ["id","firstname","lastname","salary","rate","hired","fired"]
-@test DataStreams.Data.types(sch) == (Int64, ?String, String, ?Float64, Float64, ?Date, DateTime)
+@test DataStreams.Data.types(sch) == (Int64, Union{String, Null}, String, Union{Float64, Null}, Float64, Union{Date, Null}, DateTime)
 @test sink.nt.id == [1,2,3,4,5]
 
 # B, D, E, H, J, L: replace otf Sink w/ transforms via Data.Field w/ Source=J_L


### PR DESCRIPTION
Don't get too excited or worried, there's actually not a ton of API churn here. For the most part, existing interface methods will remain mostly the same. I've strived to simplify things so that the bare minimum is just that, minimal requirements, while still allowing some advanced opt-in kind of definitions if Sources/Sinks want to get fancy. The biggest changes include:

* Moving away from DataArray/NullableArray to the use of the Nulls.jl package, in general this means seeing column types like `Vector{Union{T, Null}}` instead of `DataVector{T}` or `NullableVector{T}`
* `Data.types(schema)` will always return a tuple of column element types, i.e. `String` instead of `Vector{String}`; before it was a bit confusing because Data.Field was element types while Data.Column streaming was actual column types
* The addition of a `Data.reset!(source)` interface method for Sources that gets them back in a state where they're ready to start streaming again
* The addition of a `Data.accesspattern(source)` interface method for Sources that allows them to return `Data.RandomAccess` or `Data.Sequential` to indicate if the Source supports calling `Data.streamfrom(source, S, T, row, col)` w/ random access or if it needs to be called serially
* Simplified required Sink constructor methods: in particular, dealing w/ a `Source`'s `reference` vector is now opt-in: if a Sink defines `Data.weakrefstrings(::Type{Sink}) = true` then they're expected to also have a constructor like `Sink(schema, S, args...; reference::Vector{UInt8}=UInt8[])` where the `reference` memory will be passed; otherwise, the Sink can choose to totally ignore WeakRefStrings altogether and it will only ever get regular String element types

The other big change is we're now relying on trying to be smarter about generating inner kernel loops given certain streaming conditions (homogenous column types, small # of columns, whether the Source has a defined # of rows or not, etc.). This has required a little more type management/manipulation under the hood, but nothing too crazy. The benefits are that this can speed up code by huge orders of magnitude. You can essentially get a fully unrolled, inlined inner kernel in a lot of cases that makes the streaming process totally type stable (and freaky fast!).

Things left to do:
- [x] Do another pass over the code to make sure there's no `println`s left over or anything
- [ ] Docs rewrite, in particular having two large sections that go over: 1) how to USE the DataStreams API and 2) how to DEVELOP against the DataStreams API
- [x] Tests
- [ ] Wait for https://github.com/JuliaLang/julia/pull/22194 to be merged: I now include a "default source/sink" in DataStreams using NamedTuples, with the form `(col1=[...], col2=[...], col3=[...], ...)`. It works extremely well as a default source/sink because it's about as bare-bones as you can get, it's literally a set of ordered columns that are accessible by name. More specifically, I've tied most of the actual definitions to `const Table = NamedTuple{names, T} where {names, T <: NTuple{N, AbstractVector{S} where S}} where {N}`, which basically  means "any NamedTuple where each element is an AbstractVector of some kind". Bust out your Julia 0.6/0.7 manual on types if you want to dig more into how that type alias works.

I'd appreciate any feedback or concerns. In terms of the DataStreams ecosystem, I've ported CSV.jl, SQLite.jl, Feather.jl, and ODBC.jl over to use the updates here and everything has gone swimmingly (local tests passing and such, all packages share the same branch name `jq/gangy`). I've also done preliminary work for DataFrames/DataTables and should have respective branches for them soon.

For now, I'm only targeting a Julia 0.7 release, nothing before that.

CC: @nalimilan, @johnmyleswhite , @kleinschmidt, @ararslan , @davidagold , @davidanthoff, @andyferris, @simonbyrne, @yeesian, @ExpandingMan