### PR TITLE
Use !isnull() rather than != null

### DIFF
--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -59,7 +59,7 @@ function Schema(types=(), header=["Column$i" for i = 1:length(types)], rows::(Un
     header2 = String[string(x) for x in header]
     cols = length(header2)
     cols != length(types2) && throw(ArgumentError("length(header): $(length(header2)) must == length(types): $(length(types2))"))
-    return Schema{rows != null, Tuple{types2...}}(header2, rows, cols, metadata, Dict(n=>i for (i, n) in enumerate(header2)))
+    return Schema{!isnull(rows), Tuple{types2...}}(header2, rows, cols, metadata, Dict(n=>i for (i, n) in enumerate(header2)))
 end
 Schema(types, rows::Union{Integer,Null}, metadata::Dict=Dict()) = Schema(types, ["Column$i" for i = 1:length(types)], rows, metadata)
 


### PR DESCRIPTION
More general, and since with the new Nulls.jl null == null returns null,
this comparison no longer gives the expected result.

@quinnj Could you tag a new release after merging this? That will allow adapting DataFrames to the new behavior of `==`.