### PR TITLE
Add support for NamedTuple streaming using NamedTuples.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 WeakRefStrings 0.3.0
 Nulls 0.0.5
+NamedTuples 0.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 WeakRefStrings 0.3.0
 Nulls 0.0.5
-NamedTuples 0.4
+NamedTuples 4.0

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -694,7 +694,7 @@ function NamedTuple(sch::Data.Schema{R}, ::Type{S}=Data.Field,
         sink = @static if isdefined(Core, :NamedTuple)
                 Base.namedtuple(NamedTuple{names}, (allocate(types[i], rows, reference) for i = 1:length(types))...)
             else
-                NamedTuples.make_tuple(names)((allocate(types[i], rows, reference) for i = 1:length(types))...)
+                NamedTuples.make_tuple(collect(names))((allocate(types[i], rows, reference) for i = 1:length(types))...)
             end
         sch.rows = rows
     end

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -692,7 +692,7 @@ function NamedTuple(sch::Data.Schema{R}, ::Type{S}=Data.Field,
         names = makeunique(Data.header(sch))
 
         sink = @static if isdefined(Core, :NamedTuple)
-                Base.namedtuple(NamedTuple{names}, (allocate(types[i], rows, reference) for i = 1:length(types))...)
+                NamedTuple{names}((allocate(types[i], rows, reference) for i = 1:length(types)))
             else
                 NamedTuples.make_tuple(collect(names))((allocate(types[i], rows, reference) for i = 1:length(types))...)
             end

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -159,7 +159,7 @@ and/or for `Data.Column` streaming:
 
 ```julia
 Data.streamtype(::Type{MyPkg.Source}, ::Type{Data.Column}) = true
-``` 
+```
 """
 function streamtype end
 
@@ -589,6 +589,9 @@ end
     return r
 end
 
+
+# Source/Sink with NamedTuples
+
 if isdefined(Core, :NamedTuple)
 
 # Basically, a NamedTuple with any # of AbstractVector elements, accessed by column name
@@ -601,6 +604,22 @@ function Data.schema(df::NamedTuple{names, T}) where {names, T}
                         collect(map(string, names)), length(df) == 0 ? 0 : length(getfield(df, 1)))
 end
 
+else # if isdefined(Core, :NamedTuple)
+
+using NamedTuples
+
+# Constraint relaxed for compatability; NamedTuples.NamedTuple does not have parameters
+const Table = NamedTuple
+
+# NamedTuple Data.Source implementation
+# compute Data.Schema on the fly
+function Data.schema(df::NamedTuple)
+    return Data.Schema(Type[eltype(A) for A in values(df)],
+                        collect(map(string, keys(df))), length(df) == 0 ? 0 : length(getfield(df, 1)))
+end
+
+end # if isdefined(Core, :NamedTuple)
+
 Data.isdone(source::Table, row, col, rows, cols) = row > rows || col > cols
 function Data.isdone(source::Table, row, col)
     cols = length(source)
@@ -608,8 +627,8 @@ function Data.isdone(source::Table, row, col)
 end
 
 # We support both kinds of streaming
-Data.streamtype(::Type{NamedTuple}, ::Type{Data.Column}) = true
-Data.streamtype(::Type{NamedTuple}, ::Type{Data.Field}) = true
+Data.streamtype(::Type{<:NamedTuple}, ::Type{Data.Column}) = true
+Data.streamtype(::Type{<:NamedTuple}, ::Type{Data.Field}) = true
 
 # Data.streamfrom is pretty simple, just return the cell or column
 @inline Data.streamfrom(source::Table, ::Type{Data.Column}, ::Type{T}, row, col) where {T} = source[col]
@@ -617,9 +636,9 @@ Data.streamtype(::Type{NamedTuple}, ::Type{Data.Field}) = true
 
 # NamedTuple Data.Sink implementation
 # we support both kinds of streaming to our type
-Data.streamtypes(::Type{NamedTuple}) = [Data.Column, Data.Field]
+Data.streamtypes(::Type{<:NamedTuple}) = [Data.Column, Data.Field]
 # we support streaming WeakRefStrings
-Data.weakrefstrings(::Type{NamedTuple}) = true
+Data.weakrefstrings(::Type{<:NamedTuple}) = true
 
 # convenience methods for "allocating" a single column for streaming
 allocate(::Type{T}, rows, ref) where {T} = Vector{T}(rows)
@@ -671,7 +690,12 @@ function NamedTuple(sch::Data.Schema{R}, ::Type{S}=Data.Field,
         # for Data.Column or unknown # of rows in Data.Field, we only ever append!, so just allocate empty columns
         rows = ifelse(S == Data.Column, 0, ifelse(!R, 0, sch.rows))
         names = makeunique(Data.header(sch))
-        sink = Base.namedtuple(NamedTuple{names}, (allocate(types[i], rows, reference) for i = 1:length(types))...)
+
+        sink = @static if isdefined(Core, :NamedTuple)
+                Base.namedtuple(NamedTuple{names}, (allocate(types[i], rows, reference) for i = 1:length(types))...)
+            else
+                NamedTuples.make_tuple(names)((allocate(types[i], rows, reference) for i = 1:length(types))...)
+            end
         sch.rows = rows
     end
     return sink
@@ -693,7 +717,7 @@ end
 @inline Data.streamto!(sink::Table, ::Type{Data.Column}, column, row, col::Int, knownrows) =
     append!(getfield(sink, col), column)
 
-end # if isdefined(Core, :NamedTuple)
+
 end # module Data
 
 end # module DataStreams

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,7 +260,7 @@ sch = DataStreams.Data.schema(sink.nt)
 DataStreams.Data.streamtype(::Type{<:Source}, ::Type{DataStreams.Data.Column}) = true
 source = K_M
 sink = Sink(deepcopy(K))
-transforms = Dict(2=>x->x+1)
+transforms = Dict(2=>x->x.+1)
 Data.stream!(source, sink; transforms=transforms)
 
 sch = DataStreams.Data.schema(sink.nt)
@@ -308,7 +308,7 @@ sch = DataStreams.Data.schema(sink.nt)
 # B, D, E, H, J, L: replace otf Sink w/ transforms via Data.Field w/ Source=J_L
 source = J_L
 sink = Sink(deepcopy(J))
-transforms = Dict(2=>x->x+1)
+transforms = Dict(2=>x->x.+1)
 Data.stream!(source, Sink, sink.nt; transforms=transforms)
 
 sch = DataStreams.Data.schema(sink.nt)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,8 +31,8 @@ rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
 hired = (Union{Date, Null})[Date("2011-07-07"), Date("2016-02-19"), null, Date("2002-01-05"), Date("2008-05-15")],
 fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"), DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"), DateTime("2007-09-29T12:09:00")]
 )
-J = (; :_0=>["0"], (Symbol("_$i")=>[i] for i = 1:501)...);
-K = (; (Symbol("_$i")=>[i] for i = 1:501)...);
+J = NamedTuple{(:_0, (Symbol("_$i") for i = 1:501)...)}((["0"], ([i] for i =1:501)...))
+K = NamedTuple{((Symbol("_$i") for i = 1:501)...)}((([i] for i = 1:501)...))
 
 nms(::NamedTuple{names}) where {names} = names
 


### PR DESCRIPTION
Passes tests on 0.6, let's see what happens on 0.7.

Also for 0.6 compat but not for NamedTuples:
https://github.com/JuliaData/DataStreams.jl/compare/master...invenia:namedtuples-0.6?expand=1#diff-fce720c43af3c52c862fd7451c7374b8R111
https://github.com/JuliaData/DataStreams.jl/compare/master...invenia:namedtuples-0.6?expand=1#diff-fce720c43af3c52c862fd7451c7374b8R8