### PR TITLE
Use a single code-generating backend for all data streaming

### DIFF
--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -1,8 +1,6 @@
 __precompile__(true)
 module DataStreams
 
-export Data
-
 module Data
 
 using Missings, WeakRefStrings
@@ -640,5 +638,9 @@ include("namedtuples.jl")
 include("query.jl")
 
 end # module Data
+
+using .Data
+export Data
+export @NT
 
 end # module DataStreams

--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -465,58 +465,58 @@ datatype(T) = eval(Base.datatype_module(Base.unwrap_unionall(T)), Base.datatype_
 # generic public definitions
 const TRUE = x->true
 # the 2 methods below are safe and expected to be called from higher-level package convenience functions (e.g. CSV.read)
-function Data.stream!(source::So, ::Type{Si}, args...;
-                        append::Bool=false,
-                        transforms::Dict=Dict{Int, Function}(),
-                        filter::Function=TRUE,
-                        columns::Vector=[],
-                        kwargs...) where {So, Si}
-    S = datatype(Si)
-    sinkstreamtypes = Data.streamtypes(S)
-    for sinkstreamtype in sinkstreamtypes
-        if Data.streamtype(datatype(So), sinkstreamtype)
-            source_schema = Data.schema(source)
-            wk = weakrefstrings(S)
-            sink_schema, transforms2 = Data.transform(source_schema, transforms, wk)
-            if wk
-                sink = S(sink_schema, sinkstreamtype, append, args...; reference=Data.reference(source), kwargs...)
-            else
-                sink = S(sink_schema, sinkstreamtype, append, args...; kwargs...)
-            end
-            sourcerows = size(source_schema, 1)
-            sinkrows = size(sink_schema, 1)
-            sinkrowoffset = ifelse(append, ifelse(ismissing(sourcerows), sinkrows, max(0, sinkrows - sourcerows)), 0)
-            return Data.stream!(source, sinkstreamtype, sink, source_schema, sinkrowoffset, transforms2, filter, columns, Ref{Tuple(map(Symbol, Data.header(source_schema)))})
-        end
-    end
-    throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
-end
+# function Data.stream!(source::So, ::Type{Si}, args...;
+#                         append::Bool=false,
+#                         transforms::Dict=Dict{Int, Function}(),
+#                         filter::Function=TRUE,
+#                         columns::Vector=[],
+#                         kwargs...) where {So, Si}
+#     S = datatype(Si)
+#     sinkstreamtypes = Data.streamtypes(S)
+#     for sinkstreamtype in sinkstreamtypes
+#         if Data.streamtype(datatype(So), sinkstreamtype)
+#             source_schema = Data.schema(source)
+#             wk = weakrefstrings(S)
+#             sink_schema, transforms2 = Data.transform(source_schema, transforms, wk)
+#             if wk
+#                 sink = S(sink_schema, sinkstreamtype, append, args...; reference=Data.reference(source), kwargs...)
+#             else
+#                 sink = S(sink_schema, sinkstreamtype, append, args...; kwargs...)
+#             end
+#             sourcerows = size(source_schema, 1)
+#             sinkrows = size(sink_schema, 1)
+#             sinkrowoffset = ifelse(append, ifelse(ismissing(sourcerows), sinkrows, max(0, sinkrows - sourcerows)), 0)
+#             return Data.stream!(source, sinkstreamtype, sink, source_schema, sinkrowoffset, transforms2, filter, columns, Ref{Tuple(map(Symbol, Data.header(source_schema)))})
+#         end
+#     end
+#     throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
+# end
 
-function Data.stream!(source::So, sink::Si;
-                        append::Bool=false,
-                        transforms::Dict=Dict{Int, Function}(),
-                        filter::Function=TRUE,
-                        columns::Vector=[]) where {So, Si}
-    S = datatype(Si)
-    sinkstreamtypes = Data.streamtypes(S)
-    for sinkstreamtype in sinkstreamtypes
-        if Data.streamtype(datatype(So), sinkstreamtype)
-            source_schema = Data.schema(source)
-            wk = weakrefstrings(S)
-            sink_schema, transforms2 = transform(source_schema, transforms, wk)
-            if wk
-                sink = S(sink, sink_schema, sinkstreamtype, append; reference=Data.reference(source))
-            else
-                sink = S(sink, sink_schema, sinkstreamtype, append)
-            end
-            sourcerows = size(source_schema, 1)
-            sinkrows = size(sink_schema, 1)
-            sinkrowoffset = ifelse(append, ifelse(ismissing(sourcerows), sinkrows, max(0, sinkrows - sourcerows)), 0)
-            return Data.stream!(source, sinkstreamtype, sink, source_schema, sinkrowoffset, transforms2, filter, columns, Ref{Tuple(map(Symbol, Data.header(source_schema)))})
-        end
-    end
-    throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
-end
+# function Data.stream!(source::So, sink::Si;
+#                         append::Bool=false,
+#                         transforms::Dict=Dict{Int, Function}(),
+#                         filter::Function=TRUE,
+#                         columns::Vector=[]) where {So, Si}
+#     S = datatype(Si)
+#     sinkstreamtypes = Data.streamtypes(S)
+#     for sinkstreamtype in sinkstreamtypes
+#         if Data.streamtype(datatype(So), sinkstreamtype)
+#             source_schema = Data.schema(source)
+#             wk = weakrefstrings(S)
+#             sink_schema, transforms2 = transform(source_schema, transforms, wk)
+#             if wk
+#                 sink = S(sink, sink_schema, sinkstreamtype, append; reference=Data.reference(source))
+#             else
+#                 sink = S(sink, sink_schema, sinkstreamtype, append)
+#             end
+#             sourcerows = size(source_schema, 1)
+#             sinkrows = size(sink_schema, 1)
+#             sinkrowoffset = ifelse(append, ifelse(ismissing(sourcerows), sinkrows, max(0, sinkrows - sourcerows)), 0)
+#             return Data.stream!(source, sinkstreamtype, sink, source_schema, sinkrowoffset, transforms2, filter, columns, Ref{Tuple(map(Symbol, Data.header(source_schema)))})
+#         end
+#     end
+#     throw(ArgumentError("`source` doesn't support the supported streaming types of `sink`: $sinkstreamtypes"))
+# end
 
 function inner_loop(::Type{Val{N}}, ::Type{S}, ::Type{Val{homogeneous}}, ::Type{T}, knownrows::Type{Val{R}}, names, sourcetypes) where {N, S <: StreamType, homogeneous, T, R}
     if S == Data.Row

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -94,6 +94,7 @@ allocate(::Type{T}, rows, ref) where {T} = @uninit Vector{T}(uninitialized, rows
 # special case for WeakRefStrings
 allocate(::Type{WeakRefString{T}}, rows, ref) where {T} = WeakRefStringArray(ref, WeakRefString{T}, rows)
 allocate(::Type{Union{WeakRefString{T}, Missing}}, rows, ref) where {T} = WeakRefStringArray(ref, Union{WeakRefString{T}, Missing}, rows)
+allocate(::Type{Missing}, rows, ref) = missings(rows)
 
 # NamedTuple doesn't allow duplicate names, so make sure there are no duplicates in our column names
 function makeunique(names::Vector{String})

--- a/src/namedtuples.jl
+++ b/src/namedtuples.jl
@@ -1,9 +1,14 @@
-if !isdefined(Core, :NamedTuple)
-    using NamedTuples
-    function Base.get(f::Function, nt::NamedTuple, k)
-        return haskey(nt, k) ? nt[k] : f()
-    end
+@static if !isdefined(Core, :NamedTuple)
+using NamedTuples
+function Base.get(f::Function, nt::NamedTuple, k)
+    return haskey(nt, k) ? nt[k] : f()
 end
+else
+macro NT(args...)
+    return esc(:(($(args...),)))
+end
+end
+export @NT
 
 # Source/Sink with NamedTuple, both row and column oriented
 "A default row-oriented \"table\" that supports both the `Data.Source` and `Data.Sink` interfaces. Can be used like `Data.stream!(source, Data.RowTable)`. It is represented as a Vector of NamedTuples."

--- a/src/query.jl
+++ b/src/query.jl
@@ -291,6 +291,7 @@ function Query(source::S, actions, limit=nothing, offset=nothing) where {S}
     aggcompute_extras = Set()
     si = 0
     outcol = 1
+    isempty(actions) && (actions = [@NT(col=i,) for i = 1:len])
     for x in actions
         # if not provided, set sort index order according to order columns are given
         sortindex = get(x, :sortindex) do
@@ -363,7 +364,7 @@ Query a valid DataStreams `Data.Source` according to query `actions` and stream 
   * `group::Bool`: whether this column should be grouped, causing other columns to be aggregated
   * `aggregate::Function`: a function to reduce a columns values based on grouping keys, should be of the form `f(A::AbstractArray) => scalar`
 """
-function query(source, actions, sink=Table, args...; append::Bool=false, limit::(Integer|Void)=nothing, offset::(Integer|Void)=nothing)
+function query(source, actions=[], sink=Table, args...; append::Bool=false, limit::(Integer|Nothing)=nothing, offset::(Integer|Nothing)=nothing)
     q = Query(source, actions, limit, offset)
     sink = Data.stream!(q, sink, args...; append=append)
     return Data.close!(sink)

--- a/src/query.jl
+++ b/src/query.jl
@@ -690,7 +690,9 @@ function Data.stream!(source::So, ::Type{Si}, args...;
         trns = gettransforms(sch, transforms)
         acts = NamedTuple[@NT(col=i) for i = 1:sch.cols if !haskey(trns, i)]
         names = Data.header(sch)
-        append!(acts, [@NT(name=names[col], compute=f, computeargs=(col,)) for (col, f) in trns])
+        for (col, f) in trns
+            Base.insert!(acts, col, @NT(name=names[col], compute=f, computeargs=(col,)))
+        end
     else
         throw(ArgumentError("`transforms` is deprecated, use only `actions` to specify column transformations"))
     end
@@ -712,7 +714,9 @@ function Data.stream!(source::So, sink::Si;
         trns = gettransforms(sch, transforms)
         acts = NamedTuple[@NT(col=i) for i = 1:sch.cols if !haskey(trns, i)]
         names = Data.header(sch)
-        append!(acts, [@NT(name=names[col], compute=f, computeargs=(col,)) for (col, f) in trns])
+        for (col, f) in trns
+            Base.insert!(acts, col, @NT(name=names[col], compute=f, computeargs=(col,)))
+        end
     else
         throw(ArgumentError("`transforms` is deprecated, use only `actions` to specify column transformations"))
     end

--- a/test/query.jl
+++ b/test/query.jl
@@ -23,6 +23,17 @@ for sink in (Data.Table, Data.RowTable)
     @test cell(res, 4, 1) == 1
     @test cell(res, 4, 4) == 0
 
+    # select *
+    res = Data.query(df)
+    sch = Data.schema(res)
+    @test Data.types(sch) == (Int, String, Float64, Int)
+    @test Data.header(sch) == ["a", "b", "c", "d"]
+    @test size(sch) == (4, 4)
+    @test cell(res, 1, 1) == 1
+    @test cell(res, 1, 4) == 0
+    @test cell(res, 4, 1) == 1
+    @test cell(res, 4, 4) == 0
+
     # select * offset 1
     res = Data.query(df, [@NT(col=1,), @NT(col=2,), @NT(col=3,), @NT(col=4,)], sink, offset=1)
     sch = Data.schema(res)

--- a/test/query.jl
+++ b/test/query.jl
@@ -4,13 +4,6 @@ using DataStreams
 else
     using Test
 end
-@static if isdefined(Core, :NamedTuple)
-macro NT(args...)
-    return esc(:(($(args...),)))
-end
-else
-using NamedTuples
-end
 
 df = @NT(a=[1,2,3,1], b=["hey", "ho", "neighbor", "hi"], c=[4.0, 5.0, 6.6, 6.0], d=[0,0,0,0])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,8 +39,8 @@ rate = Float64[39.44, 33.8, 15.64, 17.67, 34.6],
 hired = (Union{Date, Missing})[Date("2011-07-07"), Date("2016-02-19"), missing, Date("2002-01-05"), Date("2008-05-15")],
 fired = DateTime[DateTime("2016-04-07T14:07:00"), DateTime("2015-03-19T15:01:00"), DateTime("2006-11-18T05:07:00"), DateTime("2002-07-18T06:24:00"), DateTime("2007-09-29T12:09:00")]
 )
-J = NamedTuple{(:_0, (Symbol("_$i") for i = 1:501)...,)}((["0"], ([i] for i =1:501)...,))
-K = NamedTuple{((Symbol("_$i") for i = 1:501)...,)}((([i] for i = 1:501)...,))
+J = NamedTuple{(:_0, (Symbol("_$i") for i = 1:501)...,)}((["0"], ([i] for i =1:501)...,));
+K = NamedTuple{((Symbol("_$i") for i = 1:501)...,)}((([i] for i = 1:501)...,));
 
 nms(::NamedTuple{names}) where {names} = names
 
@@ -75,9 +75,9 @@ Sink(sink, sch::DataStreams.Data.Schema, S, append; reference::Vector{UInt8}=UIn
 DataStreams.Data.streamtypes(::Type{Sink}) = [DataStreams.Data.Column, DataStreams.Data.Field]
 DataStreams.Data.weakrefstrings(::Type{Sink}) = true
 DataStreams.Data.streamto!(sink::Sink, ::Type{DataStreams.Data.Field}, val, row, col) =
-(C = getfield(sink.nt, col); row > length(C) ? push!(C, val) : setindex!(C, val, row); return)
+    (C = getfield(sink.nt, col); row > length(C) ? push!(C, val) : setindex!(C, val, row); return)
 DataStreams.Data.streamto!(sink::Sink, ::Type{DataStreams.Data.Column}, column, col) =
-append!(getfield(sink.nt, col), column)
+    append!(getfield(sink.nt, col), column)
 
 @testset "DataStreams" begin
 


### PR DESCRIPTION
todo
[]: implement rle, homoegenous, total # of column thresholds for alternative streaming styles
[]: remove rest of dead code in DataStreams.jl