### PR TITLE
Avoid calling eval in a generated function (it fails)

### DIFF
--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -434,7 +434,7 @@ most likely with `append=true` being passed, to enable the accumulation of sever
 Two "builtin" Source/Sink types that are included with the DataStreams package are the `Data.Table` and `Data.RowTable` types. `Data.Table` is a NamedTuple of AbstractVectors, with column names as NamedTuple fieldnames.
 This type supports both `Data.Field` and `Data.Column` streaming. `Data.RowTable` is just a Vector of NamedTuples, and as such, only supports `Data.Field` streaming.
 
-In addition, any `Data.Source` can be iterated via the `Data.rows(source)` function, which returns a NamedTuple-iterator over the rows of a source. 
+In addition, any `Data.Source` can be iterated via the `Data.rows(source)` function, which returns a NamedTuple-iterator over the rows of a source.
 """
 function stream! end
 
@@ -527,10 +527,9 @@ function inner_loop(::Type{Val{N}}, ::Type{S}, ::Type{Val{homogeneous}}, ::Type{
                 :(vals = NamedTuple{$names, $(Tuple{sourcetypes...})}(($(vals...),)))
             else
                 exprs = [:($nm::$typ) for (nm, typ) in zip(names, sourcetypes)]
-                nt = NamedTuples.make_tuple(exprs)
-                :(vals = $nt($(vals...)))
+                :(vals = eval(NamedTuples.make_tuple($exprs))($(vals...)))
             end
-        loop = quote 
+        loop = quote
             $((:($(Symbol("val_$col")) = Data.streamfrom(source, Data.Field, sourcetypes[$col], row, $col)) for col = 1:N)...)
             $out
             Data.streamto!(sink, Data.Row, vals, sinkrowoffset + row, 0, $knownrows)


### PR DESCRIPTION
This only affects the 0.6 path. This might be a huge performance hit but it goes from erroring to working so I'd say it's a good idea.

Fixes #54 