### PR TITLE
Support transforms as AbstractDict

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 WeakRefStrings 0.4.0
 Missings
-Compat
+Compat 0.41

--- a/src/query.jl
+++ b/src/query.jl
@@ -506,13 +506,18 @@ function generate_loop(knownrows::Bool, S::DataType, code::QueryCodeType, cols::
     end
 end
 
-gettransforms(sch, d::Dict{Int, <:Base.Callable}) = d
-gettransforms(sch, d::Dict{String, F}) where {F <: Base.Callable} = Dict{Int, F}(sch[x]=>f for (x, f) in d)
+gettransforms(sch, d::AbstractDict{<:Integer, <:Base.Callable}) = d
+
+function gettransforms(sch, d::AbstractDict{<:AbstractString, <:Base.Callable})
+    D = Base.typename(typeof(d))
+    D(sch[x] => f for (x, f) in d)
+end
+
 const TRUE = x->true
 
 function Data.stream!(source::So, ::Type{Si}, args...;
                         append::Bool=false,
-                        transforms::Dict=Dict{Int, Function}(),
+                        transforms::AbstractDict=Dict{Int, Function}(),
                         filter::Function=TRUE,
                         columns::Vector=[],
                         actions=[], limit=nothing, offset=nothing,
@@ -540,7 +545,7 @@ end
 
 function Data.stream!(source::So, sink::Si;
                         append::Bool=false,
-                        transforms::Dict=Dict{Int, Function}(),
+                        transforms::AbstractDict=Dict{Int, Function}(),
                         filter::Function=TRUE,
                         actions=[], limit=nothing, offset=nothing,
                         columns::Vector=[]) where {So, Si}


### PR DESCRIPTION
While working on https://github.com/JuliaData/DataStreams.jl/pull/65 it was useful to experiment with an `OrderedDict` for the `transforms`. There have been some scenarios where I've wanted this behaviour.