### PR TITLE
Fix BoundsError when using transforms

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 WeakRefStrings 0.4.0
 Missings
-Compat
+Compat 0.59

--- a/src/query.jl
+++ b/src/query.jl
@@ -523,10 +523,14 @@ function Data.stream!(source::So, ::Type{Si}, args...;
         # exclude transform columns, add scalarcomputed transform column w/ same name
         sch = Data.schema(source)
         trns = gettransforms(sch, transforms)
-        acts = Any[@NT(col=i) for i = 1:sch.cols if !haskey(trns, i)]
+        acts = Vector{Any}(undef, sch.cols)
         names = Data.header(sch)
-        for (col, f) in trns
-            Base.insert!(acts, col, @NT(name=names[col], compute=f, computeargs=(col,)))
+        for col in 1:sch.cols
+            acts[col] = if haskey(trns, col)
+                @NT(name=names[col], compute=trns[col], computeargs=(col,))
+            else
+                @NT(col=col)
+            end
         end
     else
         throw(ArgumentError("`transforms` is deprecated, use only `actions` to specify column transformations"))
@@ -550,10 +554,14 @@ function Data.stream!(source::So, sink::Si;
         # exclude transform columns, add scalarcomputed transform column w/ same name
         sch = Data.schema(source)
         trns = gettransforms(sch, transforms)
-        acts = Any[@NT(col=i) for i = 1:sch.cols if !haskey(trns, i)]
+        acts = Vector{Any}(undef, sch.cols)
         names = Data.header(sch)
-        for (col, f) in trns
-            Base.insert!(acts, col, @NT(name=names[col], compute=f, computeargs=(col,)))
+        for col in 1:sch.cols
+            acts[col] = if haskey(trns, col)
+                @NT(name=names[col], compute=trns[col], computeargs=(col,))
+            else
+                @NT(col=col)
+            end
         end
     else
         throw(ArgumentError("`transforms` is deprecated, use only `actions` to specify column transformations"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -291,6 +291,15 @@ sch = DataStreams.Data.schema(sink)
 @test DataStreams.Data.types(sch) == (Int64, Union{String, Missing}, String, Union{Float64, Missing}, Float64, Union{Date, Missing}, DateTime)
 @test sink.id == [1,2,3,4,5]
 
+# Test transforms do not raise a BoundsError
+source = J_L
+sink = Sink(deepcopy(J))
+transforms = Dict(i => x -> x for i in 2:50)
+sink = Data.stream!(source, Sink, sink.nt; transforms=transforms)
+
+sch = DataStreams.Data.schema(sink.nt)
+@test size(sch) == (1, 51)
+
 end # @testset "Data.stream!"
 
 @testset "DataStreams NamedTuple" begin


### PR DESCRIPTION
Ran into an issue with using `transforms` with CSV.jl. MWE of the original issue:

```julia
julia> using CSV

julia> CSV.read(IOBuffer(""), header=collect('a':'f'), transforms=Dict{Int,Function}(1 => floor, 2 => floor, 3 => floor, 4 => floor))
ERROR: BoundsError: attempt to access 2-element Array{Any,1} at index [4]
Stacktrace:
 [1] insert!(::Array{Any,1}, ::Int64, ::DataStreams.Data._NT_name_compute_computeargs{String,Base.#floor,Tuple{Int64}}) at ./array.jl:852
 [2] #stream!#114(::Bool, ::Dict{Int64,Function}, ::Function, ::Array{Any,1}, ::Array{Any,1}, ::Void, ::Void, ::Array{Any,1}, ::DataStreams.Data.#stream!, ::CSV.Source{Base.AbstractIOBuffer{Array{UInt8,1}},Void}, ::Type{DataFrames.DataFrame}) at /Users/omus/.julia/v0.6/DataStreams/src/query.jl:529
 [3] (::DataStreams.Data.#kw##stream!)(::Array{Any,1}, ::DataStreams.Data.#stream!, ::CSV.Source{Base.AbstractIOBuffer{Array{UInt8,1}},Void}, ::Type{DataFrames.DataFrame}) at ./<missing>:0
 [4] #read#43(::Bool, ::Dict{Int64,Function}, ::Bool, ::Array{Any,1}, ::Function, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Type{T} where T) at /Users/omus/.julia/v0.6/CSV/src/Source.jl:339
 [5] (::CSV.#kw##read)(::Array{Any,1}, ::CSV.#read, ::Base.AbstractIOBuffer{Array{UInt8,1}}, ::Type{T} where T) at ./<missing>:0 (repeats 2 times)
```