### PR TITLE
Fix no method matching sourceindex(::Void)

### DIFF
--- a/src/query.jl
+++ b/src/query.jl
@@ -97,6 +97,7 @@ end
 for (f, arg) in (:code=>:c, :T=>:t, :sourceindex=>:so, :sinkindex=>:si, :name=>:n, :sort=>:s, :args=>:a)
     @eval $f(::Type{<:QueryColumn{c, t, so, si, n, s, a}}) where {c, t, so, si, n, s, a} = $arg
     @eval $f(::QueryColumn{c, t, so, si, n, s, a}) where {c, t, so, si, n, s, a} = $arg
+    @eval $f(::Compat.Nothing) = missing
 end
 
 # E type parameter is for a tuple of integers corresponding to


### PR DESCRIPTION
Fixes #67 for both julia 0.6 and 0.7.