### PR TITLE
Fix WeakRefString streaming to RowTable

### DIFF
--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -80,7 +80,15 @@ Schema(types, rows::Union{Integer,Missing}, metadata::Dict=Dict()) = Schema(type
 
 header(sch::Schema) = sch.header
 types(sch::Schema{R, T}) where {R, T} = Tuple(T.parameters)
-anytypes(sch::Schema{R, T}) where {R, T} = collect(T.parameters)
+
+function anytypes(sch::Schema{R, T}, weakref) where {R, T}
+    types = T.parameters
+    if !weakref
+        types = map(x->x >: Missing ? ifelse(Missings.T(x) <: WeakRefString, Union{String, Missing}, x) : ifelse(x <: WeakRefString, String, x), types)
+    end
+    return collect(Any, types)
+end
+
 metadata(sch::Schema) = sch.metadata
 Base.size(sch::Schema) = (sch.rows, sch.cols)
 Base.size(sch::Schema, i::Int) = ifelse(i == 1, sch.rows, ifelse(i == 2, sch.cols, 0))

--- a/src/query.jl
+++ b/src/query.jl
@@ -192,7 +192,7 @@ function query end
 
 function query(source, actions=[], sink::Type{Si}=Table, args...; append::Bool=false, limit::(Integer|Nothing)=nothing, offset::(Integer|Nothing)=nothing, kwargs...) where {Si}
     sch = Data.schema(source)
-    types = Data.anytypes(sch)
+    types = Data.anytypes(sch, weakrefstrings(Si))
     header = Data.header(sch)
     q = Query(types, header, Vector{Any}(actions), limit, offset)
     outsink = Data.stream!(source, q, sink, args...; append=append, kwargs...)
@@ -201,7 +201,7 @@ end
 
 function query(source, actions, sink::Si; append::Bool=false, limit::(Integer|Nothing)=nothing, offset::(Integer|Nothing)=nothing) where {Si}
     sch = Data.schema(source)
-    types = Data.anytypes(sch)
+    types = Data.anytypes(sch, weakrefstrings(Si))
     header = Data.header(sch)
     q = Query(types, header, Vector{Any}(actions), limit, offset)
     outsink = Data.stream!(source, q, sink; append=append)
@@ -542,7 +542,7 @@ function Data.stream!(source::So, ::Type{Si}, args...;
         throw(ArgumentError("`transforms` is deprecated, use only `actions` to specify column transformations"))
     end
     sch = Data.schema(source)
-    types = Data.anytypes(sch)
+    types = Data.anytypes(sch, weakrefstrings(Si))
     header = Data.header(sch)
     q = Query(types, header, acts, limit, offset)
     return Data.stream!(source, q, Si, args...; append=append, kwargs...)
@@ -573,7 +573,7 @@ function Data.stream!(source::So, sink::Si;
         throw(ArgumentError("`transforms` is deprecated, use only `actions` to specify column transformations"))
     end
     sch = Data.schema(source)
-    types = Data.anytypes(sch)
+    types = Data.anytypes(sch, weakrefstrings(Si))
     header = Data.header(sch)
     q = Query(types, header, acts, limit, offset)
     return Data.stream!(source, q, sink; append=append)


### PR DESCRIPTION
Closes #66 

The issue was that streaming from a source that has a column of type `Union{WeakRefString{UInt8}, Missing}` to a sink that doesn't support WeakRefStrings (converts the column to a type of `Union{String, Missing}`) caused an error:

```julia
ERROR: MethodError: Cannot `convert` an object of type _NT_value{Union{Missings.Missing, WeakRefString{UInt8}}} to an object of type _NT_value{Union{Missings.Missing, String}}
This may have arisen from a call to the constructor _NT_value{Union{Missings.Missing, String}}(...),
since type constructors fall back to convert methods.
```

Converting the expected column types of the query fixes this error.