### PR TITLE
Remove reference to 'Core.Inference'

### DIFF
--- a/src/DataStreams.jl
+++ b/src/DataStreams.jl
@@ -109,7 +109,8 @@ end
 function transform(sch::Data.Schema{R, T}, transforms::Dict{Int, <:Base.Callable}, weakref) where {R, T}
     types = Data.types(sch)
     transforms2 = ((get(transforms, x, identity) for x = 1:length(types))...,)
-    newtypes = ((Core.Inference.return_type(transforms2[x], (types[x],)) for x = 1:length(types))...,)
+    # NOTE: `return_type` is imported, see above
+    newtypes = ((return_type(transforms2[x], (types[x],)) for x = 1:length(types))...,)
     if !weakref
         newtypes = map(x->x >: Missing ? ifelse(Missings.T(x) <: WeakRefString, Union{String, Missing}, x) : ifelse(x <: WeakRefString, String, x), newtypes)
     end


### PR DESCRIPTION
Current master [imports `return_type` from appropriate module](https://github.com/JuliaData/DataStreams.jl/blob/a3cb4221ff6f79097dd115b4b27a6d0f428e05b3/src/DataStreams.jl#L9-L13) given running session, however continues to [reference `Core.Inference`](https://github.com/JuliaData/DataStreams.jl/blob/a3cb4221ff6f79097dd115b4b27a6d0f428e05b3/src/DataStreams.jl#L112).

Should at least fix tests on nightly. 