### PR TITLE
Fix precompile error

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6
 WeakRefStrings 0.4.0
 Missings
 Compat 0.59
-NamedTuples 4.1.0
+NamedTuples 4.0.2


### PR DESCRIPTION
Note that this updates #71, not ``master``.

I believe something like this should fix the precompile problems here, while avoiding the performance problems associated with https://github.com/JuliaData/NamedTuples.jl/pull/69.

Another option would be to create these types as global constants with:
````julia
const NT1 = NamedTuples.create_namedtuple_type([:name, :compute, :computeargs], current_module())
````
in case the runtime cost of the ``create_namedtuple_type`` is too high where it occurs now.

CC @omus.